### PR TITLE
Mark tests which take >1s as slow

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,6 @@ pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 mypy --ignore-missing-imports xain && echo "===> mypy says: well done <===" &&
 
 # tests
-pytest -v -m unmarked && echo "===> pytest/unmarked says: well done <===" &&
-pytest -v -m integration && echo "===> pytest/integration says: well done <===" &&
+pytest -v && echo "===> pytest/unmarked says: well done <===" &&
 
 echo "All went well"

--- a/xain/benchmark/net/blog_cnn_test.py
+++ b/xain/benchmark/net/blog_cnn_test.py
@@ -1,11 +1,13 @@
 import random
 
 import numpy as np
+import pytest
 import tensorflow as tf
 
 from .blog_cnn import blog_cnn_compiled
 
 
+@pytest.mark.slow
 def test_num_parameters_mnist():
     # Prepare
     model = blog_cnn_compiled(input_shape=(28, 28, 1), num_classes=10)
@@ -15,6 +17,7 @@ def test_num_parameters_mnist():
     assert num_params == 412_778
 
 
+@pytest.mark.slow
 def test_num_parameters_cifar():
     # Prepare
     model = blog_cnn_compiled(input_shape=(32, 32, 3), num_classes=10)
@@ -24,6 +27,7 @@ def test_num_parameters_cifar():
     assert num_params == 536_170
 
 
+@pytest.mark.slow
 def test_seed_mnist():
     # Prepare
     random.seed(0)
@@ -48,6 +52,7 @@ def test_seed_mnist():
         np.testing.assert_equal(w_a, w_b)
 
 
+@pytest.mark.slow
 def test_seed_cifar():
     # Prepare
     random.seed(0)
@@ -72,6 +77,7 @@ def test_seed_cifar():
         np.testing.assert_equal(w_a, w_b)
 
 
+@pytest.mark.slow
 def test_seed_unequal():
     # Prepare
     random.seed(0)

--- a/xain/benchmark/net/orig_2nn_test.py
+++ b/xain/benchmark/net/orig_2nn_test.py
@@ -1,11 +1,13 @@
 import random
 
 import numpy as np
+import pytest
 import tensorflow as tf
 
 from .orig_2nn import orig_2nn_compiled
 
 
+@pytest.mark.slow
 def test_num_parameters():
     # Prepare
     model = orig_2nn_compiled()
@@ -15,6 +17,7 @@ def test_num_parameters():
     assert num_params == 199_210
 
 
+@pytest.mark.slow
 def test_seed_mnist():
     # Prepare
     random.seed(0)
@@ -39,6 +42,7 @@ def test_seed_mnist():
         np.testing.assert_equal(w_a, w_b)
 
 
+@pytest.mark.slow
 def test_seed_cifar():
     # Prepare
     random.seed(0)

--- a/xain/benchmark/net/orig_cnn_test.py
+++ b/xain/benchmark/net/orig_cnn_test.py
@@ -1,11 +1,13 @@
 import random
 
 import numpy as np
+import pytest
 import tensorflow as tf
 
 from .orig_cnn import orig_cnn_compiled
 
 
+@pytest.mark.slow
 def test_num_parameters_mnist():
     # Prepare
     model = orig_cnn_compiled(input_shape=(28, 28, 1), num_classes=10)
@@ -15,6 +17,7 @@ def test_num_parameters_mnist():
     assert num_params == 1_663_370
 
 
+@pytest.mark.slow
 def test_num_parameters_cifar():
     # Prepare
     model = orig_cnn_compiled(input_shape=(32, 32, 3), num_classes=10)
@@ -24,6 +27,7 @@ def test_num_parameters_cifar():
     assert num_params == 2_156_490
 
 
+@pytest.mark.slow
 def test_seed_mnist():
     # Prepare
     random.seed(0)
@@ -48,6 +52,7 @@ def test_seed_mnist():
         np.testing.assert_equal(w_a, w_b)
 
 
+@pytest.mark.slow
 def test_seed_cifar():
     # Prepare
     random.seed(0)
@@ -72,6 +77,7 @@ def test_seed_cifar():
         np.testing.assert_equal(w_a, w_b)
 
 
+@pytest.mark.slow
 def test_seed_unequal():
     # Prepare
     random.seed(0)

--- a/xain/benchmark/net/resnet_test.py
+++ b/xain/benchmark/net/resnet_test.py
@@ -1,6 +1,9 @@
+import pytest
+
 from .resnet import resnet20v2_compiled
 
 
+@pytest.mark.slow
 def test_num_parameters_mnist():
     # Prepare
     model = resnet20v2_compiled(input_shape=(32, 32, 3), num_classes=10)

--- a/xain/ops/results_test.py
+++ b/xain/ops/results_test.py
@@ -14,6 +14,7 @@ FLAGS = flags.FLAGS
 client = boto3.client("s3")
 
 
+@pytest.mark.slow
 @pytest.mark.integration
 def test_push_results(populated_output_dir):
     # Prepare
@@ -48,6 +49,7 @@ def test_push_results(populated_output_dir):
     ), "Cleaning up the bucket failed"
 
 
+@pytest.mark.slow
 @pytest.mark.integration
 def test_download_results(populated_results_dir, populated_S3_bucket):
     # Prepare


### PR DESCRIPTION
Also don't split the run of integration and unit tests in tests.sh script as it increases CI duration