### PR TITLE
Use clang-format to format proto files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh
+            apt-get install clang-format
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh
-            apt-get install clang-format
+            sudo apt-get update && sudo apt-get install -y clang-format
 
       - save_cache:
           paths:

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+Language: Proto
+BasedOnStyle: Google

--- a/protobuf/xain/grpc/hellonumproto.proto
+++ b/protobuf/xain/grpc/hellonumproto.proto
@@ -5,7 +5,8 @@ import "numproto/protobuf/ndarray.proto";
 package hellonumproto;
 
 service NumProtoServer {
-  rpc SayHelloNumProto (NumProtoRequest) returns (NumProtoReply) {}
+  rpc SayHelloNumProto(NumProtoRequest) returns (NumProtoReply) {
+  }
 }
 
 message NumProtoRequest {

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -9,3 +9,4 @@ cd $DIR/../
 
 isort --indent=4 -rc setup.py conftest.py xain
 black --exclude "xain/grpc/.*_pb2.*" setup.py conftest.py xain
+clang-format -i protobuf/xain/grpc/*.proto

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,9 @@ isort --check-only --indent=4 -rc setup.py conftest.py xain && echo "===> isort 
 # format code
 black --check --exclude "xain/grpc/.*_pb2.*" setup.py conftest.py xain && echo "===> black says: well done <===" &&
 
+# check format of proto files
+clang-format protobuf/xain/grpc/*.proto | diff protobuf/xain/grpc/*.proto -
+
 # lint
 pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ isort --check-only --indent=4 -rc setup.py conftest.py xain && echo "===> isort 
 black --check --exclude "xain/grpc/.*_pb2.*" setup.py conftest.py xain && echo "===> black says: well done <===" &&
 
 # check format of proto files
-clang-format protobuf/xain/grpc/*.proto | diff protobuf/xain/grpc/*.proto -
+clang-format protobuf/xain/grpc/*.proto | diff protobuf/xain/grpc/*.proto - && echo "===> clang-format says: well done <==="
 
 # lint
 pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&


### PR DESCRIPTION
This pr depends on #28 

- added .clang-format with settings to format proto files
- updated `scripts/format.sh` to also format proto files
- updated `scripts/test.sh` to check the format of proto files
- updated the CI config to install clang-format.

After this is merged `clang-format` will be a development requirement.