### PR TITLE
Require clang-format v8+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update && sudo apt-get install -y clang-format-8 python3.7
+            apt-get update && apt-get install -y clang-format-8 python3.7
             python3 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           name: install dependencies
           command: |
             apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv python3.7-venv
+            ln -s /usr/bin/clang-format-8 /usr/bin/clang-format
             python3.7 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2.1
 jobs:
+  # this job uses the ubuntu 18.04 docker image so that we have both
+  # clang-format-8+ and python3.7
   tests:
     docker:
       - image: ubuntu:18.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh
-            sudo apt-get update && sudo apt-get install -y clang-format
+            sudo apt-get update && sudo apt-get install -y clang-format-8
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            apt-get update && apt-get install -y clang-format-8 python3.7
+            apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv
             python3.7 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: install dependencies
           command: |
             apt-get update && apt-get install -y clang-format-8 python3.7
-            python3 -m venv venv
+            python3.7 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv
+            apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv python3.7-venv
             python3.7 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   tests:
     docker:
-      - image: circleci/python:3.7
+      - image: ubuntu:18.04
     steps:
       - checkout
 
@@ -14,10 +14,10 @@ jobs:
       - run:
           name: install dependencies
           command: |
+            sudo apt-get update && sudo apt-get install -y clang-format-8 python3.7
             python3 -m venv venv
             . venv/bin/activate
             ./scripts/setup.sh
-            sudo apt-get update && sudo apt-get install -y clang-format-8
 
       - save_cache:
           paths:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ POLITE NOTE: We want to point out that running the benchmarks as described below
 XAIN requires the following tools to be installed:
 
 - [Python 3.6+](https://python.org/)
-- clang-format (on macOS: `brew install clang-format`)
+- clang-format v8+ (on macOS: `brew install clang-format`)
 
 ### Clone Repository & Install XAIN
 

--- a/protobuf/xain/grpc/hellonumproto.proto
+++ b/protobuf/xain/grpc/hellonumproto.proto
@@ -5,8 +5,7 @@ import "numproto/protobuf/ndarray.proto";
 package hellonumproto;
 
 service NumProtoServer {
-  rpc SayHelloNumProto(NumProtoRequest) returns (NumProtoReply) {
-  }
+  rpc SayHelloNumProto(NumProtoRequest) returns (NumProtoReply) {}
 }
 
 message NumProtoRequest {


### PR DESCRIPTION
This pr fixes a problem with `clang-format` where there was a difference in how files are formatted that was introduced with `clang-format v8.0.0`.

- update the CI to use clang-format v8+. This required us to use the ubuntu 18.04 docker image to run the `tests` job since we need both an up to date version of clang and python3.7