### PR TITLE
Make code owner responsibilities more specific

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,27 @@
-# See for details: https://docs.gitlab.com/ee/user/project/code_owners.html
+# See for details: https://help.github.com/en/articles/about-code-owners
 
-# We can specifiy a default match using wildcards:
+# Default code owners
 * @danieljanes @tanertopal @r-marques
+
+## CI config
+/.circleci/ @r-marques @tanertopal
+
+## Protobufs
+/protobuf/ @r-marques
+
+## Python packages
+/xain/benchmark/ @danieljanes @tanertopal
+/xain/datasets/ @tanertopal
+/xain/fl/ @danieljanes
+/xain/generator/ @tanertopal
+/xain/grpc/ @r-marques
+/xain/helpers/ @danieljanes @tanertopal
+/xain/ops/ @tanertopal
+/xain/types/ @danieljanes @tanertopal
+
+## Rust packages
+/controller/ @r-marques
+/rust/ @r-marques
+
+## Scripts
+/scripts/ @tanertopal

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,6 @@
 /xain/types/ @danieljanes @tanertopal
 
 ## Rust packages
-/controller/ @r-marques
 /rust/ @r-marques
 
 ## Scripts


### PR DESCRIPTION
Making code ownership more specific to get better reviewers recommendations. @r-marques @skade @danieljanes @stjepang can you please acknowledge if I got it right? Especially on the rust side we will need to adjust it later on in subsequent PR I think. As soon as code goes into master.