### PR TITLE
Add subdirectories for aggregates

### DIFF
--- a/xain/benchmark/aggregation/final_task_accuracies.py
+++ b/xain/benchmark/aggregation/final_task_accuracies.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 from absl import app, flags, logging
 
+from xain.helpers import storage
 from xain.types import PlotValues, XticksLabels, XticksLocations
 
 from .plot import plot
@@ -102,7 +103,8 @@ def aggregate() -> str:
     :returns: Absolut path to saved plot
     """
     group_name = FLAGS.group_name
-    fname = f"plot_final_task_accuracies_{group_name}.png"
+    dname = storage.create_output_subdir(group_name)
+    fname = storage.fname_with_default_dir("plot_final_task_accuracies.png", dname)
 
     (data, xticks_args) = prepare_aggregation_data(group_name)
 

--- a/xain/benchmark/aggregation/final_task_accuracies_test.py
+++ b/xain/benchmark/aggregation/final_task_accuracies_test.py
@@ -66,8 +66,8 @@ def test_plot_final_task_accuracies(output_dir, group_name, monkeypatch):
             range(1, 12, 1),
         ),
     ]
-    fname = f"plot_final_task_accuracies_{group_name}.png"
-    expected_filepath = os.path.join(output_dir, fname)
+    fname = f"plot_final_task_accuracies.png"
+    expected_filepath = os.path.join(output_dir, group_name, fname)
     expected_sha1 = "19cbae25328694a436842de89acbbf661020b4cf"
 
     xticks_locations = range(1, 12, 1)

--- a/xain/benchmark/aggregation/plot.py
+++ b/xain/benchmark/aggregation/plot.py
@@ -43,7 +43,7 @@ def plot(
 
     # if fname is an absolute path use fname directly otherwise assume
     # fname is filename and prepend output_dir
-    fname_abspath = storage.get_abspath(fname, FLAGS.output_dir)
+    fname_abspath = storage.fname_with_default_dir(fname, FLAGS.output_dir)
 
     plt.figure()
     plt.ylim(0.0, ylim_max)

--- a/xain/benchmark/aggregation/task_accuracies.py
+++ b/xain/benchmark/aggregation/task_accuracies.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 
 from absl import app, flags, logging
 
+from xain.helpers import storage
 from xain.types import PlotValues
 
 from .plot import plot
@@ -85,7 +86,8 @@ def aggregate() -> str:
     :returns: Absolut path to saved plot
     """
     group_name = FLAGS.group_name
-    fname = f"plot_task_accuracies_{group_name}.png"
+    dname = storage.create_output_subdir(group_name)
+    fname = storage.fname_with_default_dir("plot_task_accuracies.png", dname)
 
     data = prepare_aggregation_data(group_name)
 

--- a/xain/benchmark/aggregation/task_accuracies_test.py
+++ b/xain/benchmark/aggregation/task_accuracies_test.py
@@ -22,8 +22,8 @@ def test_plot_task_accuracies(output_dir, group_name, monkeypatch):
             range(1, 12, 1),
         ),
     ]
-    fname = f"plot_task_accuracies_{group_name}.png"
-    expected_filepath = os.path.join(output_dir, fname)
+    fname = f"plot_task_accuracies.png"
+    expected_filepath = os.path.join(output_dir, group_name, fname)
     expected_sha1 = "7138bde2b95eedda6b05b665cc35a6cf204e35e1"
 
     def mock_prepare_aggregation_data(_: str):

--- a/xain/generator/partition_volume_distributions.py
+++ b/xain/generator/partition_volume_distributions.py
@@ -130,16 +130,16 @@ def plot_fashion_mnist_dist():
         plt.plot(xs, np.array(dist))
     plt.legend(legend, loc="upper left")
 
-    fname_abspath = storage.get_abspath(
-        "plot_fashion_mnist_partition_volume_dist", FLAGS.output_dir
-    )
-    plt.savefig(fname=fname_abspath, format=FORMAT)
+    dname = storage.create_output_subdir("partition_volume_distributions")
+    fname = storage.fname_with_default_dir("plot_fashion_mnist", dname)
+
+    plt.savefig(fname=fname, format=FORMAT)
 
     # FIXME: Matplotlib is currently using agg, which is a non-GUI
     #        backend, so cannot show the figure.
     # plt.show()
 
-    return fname_abspath
+    return fname
 
 
 def main():

--- a/xain/helpers/storage.py
+++ b/xain/helpers/storage.py
@@ -29,8 +29,19 @@ def listdir_recursive(dname: str, relpath=True):
     return files
 
 
-def get_abspath(fname: str, dname: str = None) -> str:
+def create_output_subdir(dname: str) -> str:
+    if os.path.isabs(dname):
+        raise Exception("Please provide a relative directory name")
 
+    dname = os.path.join(FLAGS.output_dir, dname)
+
+    os.makedirs(dname, exist_ok=True)
+
+    return dname
+
+
+def fname_with_default_dir(fname: str, dname: str = None) -> str:
+    """Returns fname if its a absolute path otherwise joins it with dname"""
     if os.path.isabs(fname):
         return fname
 
@@ -41,12 +52,12 @@ def get_abspath(fname: str, dname: str = None) -> str:
 
 
 def write_json(results: Dict, fname: str):
-    fname = get_abspath(fname, FLAGS.output_dir)
+    fname = fname_with_default_dir(fname, FLAGS.output_dir)
     with open(fname, "w") as outfile:
         json.dump(results, outfile, indent=2, sort_keys=True)
 
 
 def read_json(fname: str):
-    fname = get_abspath(fname, FLAGS.output_dir)
+    fname = fname_with_default_dir(fname, FLAGS.output_dir)
     with open(fname, "r") as outfile:
         return json.loads(outfile.read())

--- a/xain/helpers/storage_test.py
+++ b/xain/helpers/storage_test.py
@@ -3,25 +3,25 @@ import os
 from . import storage
 
 
-def test_get_abspath_fname_with_absolute_path():
+def test_fname_with_default_dir_absolute_path():
     # Prepare
     fname = "/my/absolute/path/myfile"
     expected_abspath = fname
 
     # Execute
-    actual_abspath = storage.get_abspath(fname)
+    actual_abspath = storage.fname_with_default_dir(fname)
 
     # Assert
     assert expected_abspath == actual_abspath
 
 
-def test_get_abspath_fname_only_filename(output_dir):
+def test_fname_with_default_dir_relative_path(output_dir):
     # Prepare
     fname = "myfile"
     expected_abspath = os.path.join(output_dir, fname)
 
     # Execute
-    actual_abspath = storage.get_abspath(fname, output_dir)
+    actual_abspath = storage.fname_with_default_dir(fname, output_dir)
 
     # Assert
     assert expected_abspath == actual_abspath


### PR DESCRIPTION
To enable multiple aggregates in a clean way in the output directory will now contain a sub-directory for each group for which the aggregate function is called