### PR TITLE
Collect and report optimizer state from each selected participant

### DIFF
--- a/xain/benchmark/bench_cl.py
+++ b/xain/benchmark/bench_cl.py
@@ -70,7 +70,7 @@ def bench_cl_ul(
 ):
     start = time.time()
     if use_coordinator:
-        hist, _, _, loss, acc = run.federated_training(
+        hist, _, _, _, loss, acc = run.federated_training(
             "blog_cnn", [xy_train], xy_val, xy_test, R=epochs, E=1, C=0, B=B
         )
     else:

--- a/xain/benchmark/bench_ea.py
+++ b/xain/benchmark/bench_ea.py
@@ -24,7 +24,7 @@ def benchmark_evolutionary_avg():
     # Run Federated Learning with evolutionary aggregation
     evaluator = Evaluator(orig_cnn_compiled(), xy_val)  # FIXME refactor
     aggregator = EvoAgg(evaluator)
-    _, _, _, loss_a, acc_a = run.federated_training(
+    _, _, _, _, loss_a, acc_a = run.federated_training(
         "blog_cnn",
         xy_parts,
         xy_val,
@@ -37,7 +37,7 @@ def benchmark_evolutionary_avg():
     )
 
     # Run Federated Learning with weighted average aggregation
-    _, _, _, loss_b, acc_b = run.federated_training(
+    _, _, _, _, loss_b, acc_b = run.federated_training(
         "blog_cnn",
         xy_parts,
         xy_val,

--- a/xain/benchmark/exec/__main__.py
+++ b/xain/benchmark/exec/__main__.py
@@ -31,7 +31,10 @@ def main(_):
     # Execute training
     start = time.time()
     partition_id = FLAGS.partition_id
+
+    hist_opt_configs = None  # For unitary training
     hist_metrics = None  # For unitary training
+
     if partition_id is not None:  # Use only a single partition if required (unitary)
         hist, loss, acc = run.unitary_training(
             model_name=FLAGS.model,
@@ -42,7 +45,7 @@ def main(_):
             B=FLAGS.B,
         )
     else:
-        hist, _, hist_metrics, loss, acc = run.federated_training(
+        hist, _, hist_opt_configs, hist_metrics, loss, acc = run.federated_training(
             model_name=FLAGS.model,
             xy_train_partitions=xy_train_partitions,
             xy_val=xy_val,
@@ -72,6 +75,7 @@ def main(_):
         "loss": float(loss),
         "acc": float(acc),
         "hist": hist,
+        "hist_opt_configs": hist_opt_configs,
         "hist_metrics": hist_metrics,
     }
     storage.write_json(res, fname="results.json")

--- a/xain/benchmark/exec/run.py
+++ b/xain/benchmark/exec/run.py
@@ -1,6 +1,6 @@
 import random
 import time
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import tensorflow as tf
@@ -75,7 +75,14 @@ def federated_training(
     C: float,
     B: int,
     aggregator: Aggregator = None,
-) -> Tuple[KerasHistory, List[List[KerasHistory]], List[List[Metrics]], float, float]:
+) -> Tuple[
+    KerasHistory,
+    List[List[KerasHistory]],
+    List[List[Dict]],
+    List[List[Metrics]],
+    float,
+    float,
+]:
     # Initialize participants and coordinator
     # Note that there is no need for common initialization at this point: Common
     # initialization will happen during the first few rounds because the coordinator will
@@ -106,13 +113,13 @@ def federated_training(
     )
 
     # Train model
-    hist_co, hist_ps, hist_metrics = coordinator.fit(num_rounds=R)
+    hist_co, hist_ps, hist_opt_configs, hist_metrics = coordinator.fit(num_rounds=R)
 
     # Evaluate final performance
     loss, acc = coordinator.evaluate(xy_test)
 
     # Report results
-    return hist_co, hist_ps, hist_metrics, loss, acc
+    return hist_co, hist_ps, hist_opt_configs, hist_metrics, loss, acc
 
 
 # FIXME remove
@@ -144,7 +151,7 @@ def unitary_versus_federated(
 
     # Train CNN using federated learning on all partitions
     logging.info("Run federated learning using all partitions")
-    fl_hist, _, _, fl_loss, fl_acc = federated_training(
+    fl_hist, _, _, _, fl_loss, fl_acc = federated_training(
         model_name, xy_train_partitions, xy_val, xy_test, R=R, E=E, C=C, B=B
     )
 

--- a/xain/fl/participant/participant_test.py
+++ b/xain/fl/participant/participant_test.py
@@ -48,7 +48,7 @@ def test_Participant_num_examples():
     weights = model_provider.init_model().get_weights()
 
     # Execute
-    (_, num_examples_actual), _ = participant.train_round(weights, 2, 0)
+    (_, num_examples_actual), _, _ = participant.train_round(weights, 2, 0)
 
     # Assert
     assert num_examples_actual == num_examples_expected


### PR DESCRIPTION
Next to updated model parameters and metrics, the participants now also return the optimizer state (containing e.g. the learning rate).

Note that the return types start to get quite complex. I've created a follow-up task (XP-102) to refactor this and unify some of those types into a single type. The reason I haven't refactored it already is twofold:
1. To keep the scope of this PR reasonable
2. To not break aggregation code which relies on the current `results.json` file structure