### PR TITLE
Create standalone script to list running AWS instances

### DIFF
--- a/scripts/ls_running_instances.sh
+++ b/scripts/ls_running_instances.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e  # Exit immediately if a command exits with a non-zero status
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/../
+
+AWS_PROFILE=xain-xain aws ec2 describe-instances  --filters Name=instance-state-code,Values=16 | jq '.Reservations[].Instances[] | "\(.Tags[].Value), \(.PublicIpAddress)"'


### PR DESCRIPTION
This script only captures @tanertopal 's single-line statement to list running AWS instances in an attempt to make it easier to access for everyone.