### PR TITLE
Learning rate aggregation

### DIFF
--- a/xain/benchmark/aggregation/aggregation.py
+++ b/xain/benchmark/aggregation/aggregation.py
@@ -3,7 +3,11 @@ from typing import Callable, Dict
 
 from absl import flags, logging
 
-from xain.benchmark.aggregation import final_task_accuracies, task_accuracies
+from xain.benchmark.aggregation import (
+    final_task_accuracies,
+    learning_rate,
+    task_accuracies,
+)
 from xain.helpers import storage
 
 FLAGS = flags.FLAGS
@@ -22,6 +26,7 @@ def aggregate():
 def flul_aggregation():
     logging.info("flul_aggregation started")
     task_accuracies.aggregate()
+    learning_rate.aggregate()
 
 
 def cpp_aggregation():

--- a/xain/benchmark/aggregation/conftest.py
+++ b/xain/benchmark/aggregation/conftest.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def results_json_fname(tmpdir):
+    results = {
+        "hist_opt_configs": [
+            [{"learning_rate": 0.1}, {"learning_rate": 0.1}],
+            [{"learning_rate": 0.2}, {"learning_rate": 0.2}],
+        ]
+    }
+
+    fname = Path(tmpdir).joinpath("results.json")
+
+    with open(fname, "w") as outfile:
+        json.dump(results, outfile, indent=2, sort_keys=True)
+
+    return str(fname)

--- a/xain/benchmark/aggregation/conftest.py
+++ b/xain/benchmark/aggregation/conftest.py
@@ -5,12 +5,25 @@ import pytest
 
 
 @pytest.fixture
-def results_json_fname(tmpdir):
+def unitary_results_json_fname(tmpdir):
+    results = {"partition_id": 0, "hist_opt_configs": None}
+
+    fname = Path(tmpdir).joinpath("results.json")
+
+    with open(fname, "w") as outfile:
+        json.dump(results, outfile, indent=2, sort_keys=True)
+
+    return str(fname)
+
+
+@pytest.fixture
+def federated_results_json_fname(tmpdir):
     results = {
+        "partition_id": None,
         "hist_opt_configs": [
             [{"learning_rate": 0.1}, {"learning_rate": 0.1}],
             [{"learning_rate": 0.2}, {"learning_rate": 0.2}],
-        ]
+        ],
     }
 
     fname = Path(tmpdir).joinpath("results.json")

--- a/xain/benchmark/aggregation/conftest.py
+++ b/xain/benchmark/aggregation/conftest.py
@@ -1,34 +1,71 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
 
+# TODO: Use TaskResults class to read/write task results
+#       to have one central way of reading/writing results
+
+results_unitary = {
+    # Does not contain all keys which are in a actual results.json file
+    # just the ones nessecary for the currently existing tests
+    "task_name": "unitary",
+    "task_label": "unitary label",
+    "partition_id": 0,
+    "hist_opt_configs": None,
+}
+
+
+results_federated = {
+    # Does not contain all keys which are in a actual results.json file
+    # just the ones nessecary for the currently existing tests
+    "task_name": "federated",
+    "task_label": "federated label",
+    "partition_id": None,
+    "hist_opt_configs": [
+        [{"learning_rate": 0.1}, {"learning_rate": 0.1}],
+        [{"learning_rate": 0.2}, {"learning_rate": 0.2}],
+    ],
+}
+
+
+@pytest.fixture
+def group_dir(tmpdir):
+    """Group dir with one unitary and one federated task each containing a results.json"""
+    task_unitary_dir = Path(tmpdir).joinpath("unitary")
+    task_federated_dir = Path(tmpdir).joinpath("federated")
+
+    os.makedirs(task_unitary_dir)
+    os.makedirs(task_federated_dir)
+
+    unitary_results_fname = task_unitary_dir.joinpath("results.json")
+    federated_results_fname = task_federated_dir.joinpath("results.json")
+
+    with open(unitary_results_fname, "w") as outfile:
+        json.dump(results_unitary, outfile, indent=2, sort_keys=True)
+
+    with open(federated_results_fname, "w") as outfile:
+        json.dump(results_federated, outfile, indent=2, sort_keys=True)
+
+    return tmpdir
+
 
 @pytest.fixture
 def unitary_results_json_fname(tmpdir):
-    results = {"partition_id": 0, "hist_opt_configs": None}
-
     fname = Path(tmpdir).joinpath("results.json")
 
     with open(fname, "w") as outfile:
-        json.dump(results, outfile, indent=2, sort_keys=True)
+        json.dump(results_unitary, outfile, indent=2, sort_keys=True)
 
     return str(fname)
 
 
 @pytest.fixture
 def federated_results_json_fname(tmpdir):
-    results = {
-        "partition_id": None,
-        "hist_opt_configs": [
-            [{"learning_rate": 0.1}, {"learning_rate": 0.1}],
-            [{"learning_rate": 0.2}, {"learning_rate": 0.2}],
-        ],
-    }
-
     fname = Path(tmpdir).joinpath("results.json")
 
     with open(fname, "w") as outfile:
-        json.dump(results, outfile, indent=2, sort_keys=True)
+        json.dump(results_federated, outfile, indent=2, sort_keys=True)
 
     return str(fname)

--- a/xain/benchmark/aggregation/final_task_accuracies.py
+++ b/xain/benchmark/aggregation/final_task_accuracies.py
@@ -116,8 +116,6 @@ def aggregate() -> str:
         xlabel="partitioning grade",
         ylabel="accuracy",
         fname=fname,
-        save=True,
-        show=False,
         ylim_max=1.0,
         xlim_max=12,
         xticks_args=xticks_args,

--- a/xain/benchmark/aggregation/learning_rate.py
+++ b/xain/benchmark/aggregation/learning_rate.py
@@ -1,0 +1,119 @@
+import os
+from typing import List, Optional, Tuple
+
+from absl import app, flags, logging
+
+from xain.helpers import storage
+from xain.types import PlotValues
+
+from .plot import plot
+from .results import GroupResult, TaskResult
+
+FLAGS = flags.FLAGS
+
+
+def read_task_values(task_result: TaskResult) -> Tuple[str, Optional[List[float]]]:
+    """Reads unitary and federated accuracy from results.json
+
+    Args:
+        fname (str): path to results.json file containing required fields
+
+    Returns
+        class, label, final_accuracy (str, str, float): e.g. ("VisionTask", "cpp01", 0.92)
+    """
+    return (task_result.get_label(), task_result.get_learning_rates())
+
+
+def read_all_task_values(group_dir: str) -> List[Tuple[str, List[float]]]:
+    """
+    Reads results directory for given group_dir and returns a list of
+    tuples with label and list of learning rates
+
+    Args:
+        group_dir (str): path to directory to be read
+
+    """
+    task_results = GroupResult(group_dir).get_results()
+    # Reatur accuracies from each file and return list of values in tuples
+    all_tasks = [read_task_values(task_result) for task_result in task_results]
+
+    federated_tasks = [
+        (label, learning_rates)
+        for label, learning_rates in all_tasks
+        if learning_rates is not None
+    ]
+
+    return federated_tasks
+
+
+def prepare_aggregation_data(group_name: str) -> List[PlotValues]:
+    """Constructs and returns learning rate curves
+
+    Args:
+        group_name (str): group name for which to construct the curves
+
+    Returns:
+        (
+            [
+                ("task_name_1", learning_rates, indices)
+                ("task_name_2", learning_rates, indices)
+            ],
+        )
+    """
+    group_dir = os.path.join(FLAGS.results_dir, group_name)
+    # List of tuples (benchmark_name, unitary_accuracy, federated_accuracy)
+    labels_and_lrs = read_all_task_values(group_dir=group_dir)
+
+    assert labels_and_lrs, "No values for group found"
+
+    return [(label, lrs, list(range(len(lrs)))) for label, lrs in labels_and_lrs]
+
+
+def aggregate() -> str:
+    """Plots learning rate for federated tasks in a group
+
+    :param data: List of tuples which represent (name, values, indices)
+    :param fname: Filename of plot
+
+    :returns: Absolut path to saved plot
+    """
+    group_name = FLAGS.group_name
+    dname = storage.create_output_subdir(group_name)
+    fname = storage.fname_with_default_dir("plot_learning_rates.png", dname)
+
+    data = prepare_aggregation_data(group_name)
+
+    ylim_max: float = 0
+    xlim_max = 0
+
+    for _, lrs, ylabel in data:
+        if ylabel is not None:
+            xlim_max = max(ylabel + [xlim_max])
+
+        for lr in lrs:
+            ylim_max = max(lr, ylim_max)
+
+    ylim_max *= 1.1
+    xlim_max += 1
+
+    assert data, "Expecting a list with at least one item"
+
+    fpath = plot(
+        data,
+        title="Optimizer learning rates for federated training tasks",
+        xlabel="round",
+        ylabel="learning rate",
+        fname=fname,
+        ylim_max=ylim_max,
+        xlim_max=xlim_max,
+        legend_loc="upper right",
+    )
+
+    logging.info(f"Data plotted and saved in {fpath}")
+
+    return fpath
+
+
+def app_run_aggregate():
+    flags.mark_flag_as_required("group_name")
+    app.run(main=lambda _: aggregate())

--- a/xain/benchmark/aggregation/learning_rate_test.py
+++ b/xain/benchmark/aggregation/learning_rate_test.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+from absl import flags
+
+from xain.helpers import sha1
+
+from . import learning_rate
+
+FLAGS = flags.FLAGS
+
+
+@pytest.mark.integration
+def test_read_all_task_values(group_dir):
+    # Prepare
+    expected_results = [("federated label", [0.1, 0.2])]
+
+    # Execute
+    actual_results = learning_rate.read_all_task_values(group_dir)
+
+    # Assert
+    assert actual_results == expected_results
+
+
+@pytest.mark.integration
+def test_plot_learning_rate(output_dir, group_name, monkeypatch):
+    # Prepare
+    data = [
+        ("federated 1 - label", [0.10, 0.05, 0.03, 0.02], [1, 2, 3, 4]),
+        ("federated 2 - label", [0.09, 0.07, 0.06, 0.04], [1, 2, 3, 4]),
+    ]
+    fname = f"plot_learning_rates.png"
+    expected_filepath = os.path.join(output_dir, group_name, fname)
+    expected_sha1 = "599daf7563f41289a8eed2b59aba3c5d312eeab1"
+
+    def mock_prepare_aggregation_data(_: str):
+        return data
+
+    monkeypatch.setattr(
+        learning_rate, "prepare_aggregation_data", mock_prepare_aggregation_data
+    )
+
+    # Execute
+    actual_filepath = learning_rate.aggregate()
+
+    # If any error occurs we will be able to look at the plot. If the the ploting
+    # logic is changed the file under this path can be used to get the new hash
+    # after evaluating the rendered plot
+    print(actual_filepath)
+
+    # Assert
+    assert expected_filepath == actual_filepath
+    assert expected_sha1 == sha1.checksum(actual_filepath), "Checksum not matching"

--- a/xain/benchmark/aggregation/plot.py
+++ b/xain/benchmark/aggregation/plot.py
@@ -35,7 +35,7 @@ def plot(
 ) -> str:
     """
     :param data: List of tuples where each represents a line in the plot
-                 with tuple beeing (name, values, indices)
+                 with tuple beeing (name, values, Optional[indices])
 
     :returns: For save=True returns absolut path to saved file otherwise None
     """

--- a/xain/benchmark/aggregation/results.py
+++ b/xain/benchmark/aggregation/results.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from xain.helpers import storage
 
@@ -21,15 +21,21 @@ class TaskResult(ABC):
     def get_accuracies(self) -> List[float]:
         return self.data["hist"]["val_acc"]
 
-    def get_learning_rates(self) -> List[float]:
-        """Will extract learning rate in each round from hist_opt_configs
-        which has a List[List[Dict[str, any]]] type. Where the top level
-        list contains ROUNDS elements and the second level lists contain
-        number of participants dictionaries (one for each participant)"""
+    def get_learning_rates(self) -> Optional[List[float]]:
+        """Will extract learning rate for federated task results in each round
+        from hist_opt_configs which has a List[List[Dict[str, any]]] type. The
+        top level list contains ROUNDS elements and the second level lists
+        contain number of participants dictionaries (one for each participant).
+        As unitary task results don't have a history of optimizer configs
+        None will be returned.
+        """
+        if self.is_unitary():
+            return None
+
         hist_opt_configs = self.data["hist_opt_configs"]
 
-        # We extract the learning rate only from the first participant
-        # as the participants share the same learning rate in each round
+        # Extract learning rate only from the first participant as the participants
+        # share the same learning rate in each round
         learning_rates = [
             participants_in_round[0]["learning_rate"]
             for participants_in_round in hist_opt_configs

--- a/xain/benchmark/aggregation/results.py
+++ b/xain/benchmark/aggregation/results.py
@@ -21,6 +21,22 @@ class TaskResult(ABC):
     def get_accuracies(self) -> List[float]:
         return self.data["hist"]["val_acc"]
 
+    def get_learning_rates(self) -> List[float]:
+        """Will extract learning rate in each round from hist_opt_configs
+        which has a List[List[Dict[str, any]]] type. Where the top level
+        list contains ROUNDS elements and the second level lists contain
+        number of participants dictionaries (one for each participant)"""
+        hist_opt_configs = self.data["hist_opt_configs"]
+
+        # We extract the learning rate only from the first participant
+        # as the participants share the same learning rate in each round
+        learning_rates = [
+            participants_in_round[0]["learning_rate"]
+            for participants_in_round in hist_opt_configs
+        ]
+
+        return learning_rates
+
     def get_E(self) -> int:
         return self.data["E"]
 

--- a/xain/benchmark/aggregation/results_test.py
+++ b/xain/benchmark/aggregation/results_test.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from .results import TaskResult
+
+
+def test_get_learning_rates(results_json_fname):
+    # Prepare
+    result = TaskResult(results_json_fname)
+
+    expected_lr_round_1 = 0.1
+    expected_lr_round_2 = 0.2
+
+    # Execute
+    learning_rates: List[float] = result.get_learning_rates()
+
+    # Assert
+    assert isinstance(learning_rates, list)
+    assert len(learning_rates) == 2
+
+    assert learning_rates[0] == expected_lr_round_1
+    assert learning_rates[1] == expected_lr_round_2

--- a/xain/benchmark/aggregation/results_test.py
+++ b/xain/benchmark/aggregation/results_test.py
@@ -3,9 +3,20 @@ from typing import List
 from .results import TaskResult
 
 
-def test_get_learning_rates(results_json_fname):
+def test_get_learning_rates_unitary(unitary_results_json_fname):
     # Prepare
-    result = TaskResult(results_json_fname)
+    result = TaskResult(unitary_results_json_fname)
+
+    # Execute
+    learning_rates = result.get_learning_rates()
+
+    # Assert
+    assert learning_rates is None
+
+
+def test_get_learning_rates_federated(federated_results_json_fname):
+    # Prepare
+    result = TaskResult(federated_results_json_fname)
 
     expected_lr_round_1 = 0.1
     expected_lr_round_2 = 0.2

--- a/xain/benchmark/aggregation/task_accuracies.py
+++ b/xain/benchmark/aggregation/task_accuracies.py
@@ -99,8 +99,6 @@ def aggregate() -> str:
         title="Validation set accuracy for unitary and federated learning",
         ylabel="accuracy",
         fname=fname,
-        save=True,
-        show=False,
         ylim_max=1.0,
         xlim_max=xlim_max,
     )


### PR DESCRIPTION
Adds a new aggregate method which will for all federated learning tasks which contain a history of optimizer configurations plot the learning rates as an additional plot with one curve per federated task.
Unitary tasks will be ignored as they do not contain the optimizer configuration.