### PR TITLE
Update setup.py for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,8 @@ install_requires = [
     "numproto==0.2.0",  # Apache License 2.0
     "grpcio-tools==1.23.0",  # Apache License 2.0
     "mypy-protobuf==1.15",  # Apache License 2.0
+    "tensorflow==1.14.0",  # Apache 2.0
 ]
-
-cpu_require = ["tensorflow==1.14.0"]  # Apache 2.0
 
 gpu_require = ["tensorflow-gpu==1.14.0"]  # Apache 2.0
 
@@ -121,7 +120,6 @@ setup(
     tests_require=tests_require,
     extras_require={
         "test": tests_require,
-        "cpu": cpu_require,
         "gpu": gpu_require,
         "dev": dev_require + tests_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ if sys.version_info < (3, 6):
     sys.exit("Please use Python version 3.6 or higher.")
 
 
+# get readme
+with open("README.md", "r") as fp:
+    readme = fp.read()
+
+
 # Handle protobuf
 class CustomDevelopCommand(develop):
     def run(self):
@@ -89,6 +94,8 @@ setup(
     name="xain",
     version="0.1.0",
     description="XAIN demonstrates automated architecture search in federated learning environments.",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     url="https://github.com/xainag/xain",
     author=[
         "Daniel J. Beutel <daniel.beutel@xain.io>",

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ install_requires = [
     "grpcio==1.23.0",  # Apache License 2.0
     "protobuf==3.9.1",  # 3-Clause BSD License
     "numproto==0.2.0",  # Apache License 2.0
-    "grpcio-tools==1.23.0",  # Apache License 2.0
-    "mypy-protobuf==1.15",  # Apache License 2.0
     "tensorflow==1.14.0",  # Apache 2.0
 ]
 
@@ -81,6 +79,8 @@ dev_require = [
     "isort==4.3.20",  # MIT
     "rope==0.14.0",  # GNU GPL
     "pip-licenses==1.15.2",  # MIT License
+    "grpcio-tools==1.23.0",  # Apache License 2.0
+    "mypy-protobuf==1.15",  # Apache License 2.0
 ]
 
 tests_require = [


### PR DESCRIPTION
- `setup.py` now uses `README.md` as a long description of the project. This way the README will appear as a package description on pypi
- `tensorflow` is now an install requirement. This allows us to install the xain package without having to specify any extras. `pip install xain` instead of `pip install xain[cpu]`
- Moved some grpc related tools to the dev dependencies. This way they are not installed in non-dev environments.