### PR TITLE
Initial support for sphinx documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ install the `xain` package with support for GPUs just run:
 $ pip install xain[gpu]
 ```
 
+### Running training sessions and benchmarks
+
+To run training sessions, see the [benchmark package](https://github.com/xainag/xain/tree/master/xain/benchmark)
+
 ## Install from source
 
 For development we require some extra system dependencies:
@@ -53,9 +57,18 @@ You can verify the installation by running the tests
 $ pytest
 ```
 
-### Running training sessions and benchmarks
+### Building the Documentation
 
-To run training sessions, see the [benchmark package](https://github.com/xainag/xain/tree/master/xain/benchmark)
+The project documentation resides under `docs/`. To build the documentation
+run:
+```shell
+$ cd docs/
+$ make html
+```
+
+The generated documentation will be under `docs/_build/html/`. You can open the
+root of the documentation by opening `docs/_build/html/index.html` on your
+favorite browser.
 
 ## Related Papers and Articles
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'XAIN'
+copyright = '2019, XAIN Contributors'
+author = 'XAIN Contributors'
+
+# The full version, including alpha/beta/rc tags
+release = '0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. XAIN documentation master file, created by
+   sphinx-quickstart on Fri Sep 27 10:21:36 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to XAIN's documentation!
+================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ tests_require = [
     "pytest-watch==4.2.0",  # MIT
 ]
 
+docs_require = ["Sphinx==2.2.0"]  # BSD
+
 setup(
     name="xain",
     version=version["__version__"],
@@ -135,7 +137,8 @@ setup(
     extras_require={
         "test": tests_require,
         "gpu": gpu_require,
-        "dev": dev_require + tests_require,
+        "docs": docs_require,
+        "dev": dev_require + tests_require + docs_require,
     },
     cmdclass={"develop": CustomDevelopCommand},
     entry_points={


### PR DESCRIPTION
- Added new `docs` extra to setup.py to hold all documentation related
  dependencies.
- Updated README with instructions on how to build the documentation

Note that all files currently under `docs/` are auto generated by sphinx