### PR TITLE
CI support for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -52,4 +52,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,6 +38,9 @@ pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 # type checks
 mypy --ignore-missing-imports xain && echo "===> mypy says: well done <===" &&
 
+# documentation checks
+sphinx-build -W -b html docs/ docs/_build/ && echo "===> sphinx-build says: well done <===" &&
+
 # tests
 pytest -v && echo "===> pytest/unmarked says: well done <===" &&
 


### PR DESCRIPTION
The goal of this pr is to have the CI check if the documentation builds without warnings.

Since this is a simple check I decided to just add an extra check in `scripts/test.sh`.

Once we integrate with readthedocs we may consider having a separate job for the documentation.