### PR TITLE
Add code documentation to sphinx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv python3.7-venv
+            apt-get update && apt-get install -y clang-format-8 python3.7 python3-venv python3.7-venv make
             ln -s /usr/bin/clang-format-8 /usr/bin/clang-format
             python3.7 -m venv venv
             . venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_code_reference/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The project documentation resides under `docs/`. To build the documentation
 run:
 ```shell
 $ cd docs/
-$ make html
+$ make docs
 ```
 
 The generated documentation will be under `docs/_build/html/`. You can open the

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,10 @@ help:
 
 .PHONY: help Makefile
 
+docs:
+	sphinx-apidoc --doc-project "Code Reference" -f -d 3 --tocfile index -o ./_code_reference/ ../xain/
+	make html
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
+
 # get version
 _version = {}
 with open("../xain/__version__.py") as fp:
@@ -40,6 +41,8 @@ release = _version["__version__"]
 # ones.
 extensions = [
     "recommonmark",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
 ]
 
 source_suffix = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ production.
 
 
 User Guide
-------------
+----------
 
 .. toctree::
    :maxdepth: 2
@@ -36,3 +36,12 @@ User Guide
    intro
    install
    quick
+
+
+API Documentation
+-----------------
+
+.. toctree::
+    :maxdepth: 1
+
+    _code_reference/index

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,7 @@ The project documentation resides under `docs/`. To build the documentation
 run:
 ```shell
 $ cd docs/
-$ make html
+$ make docs
 ```
 
 The generated documentation will be under `docs/_build/html/`. You can open the

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,7 +39,7 @@ pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 mypy --ignore-missing-imports xain && echo "===> mypy says: well done <===" &&
 
 # documentation checks
-(cd docs/ && SPHINXOPTS="-W" make html) && echo "===> sphinx-build says: well done <===" &&
+(cd docs/ && SPHINXOPTS="-W" make docs) && echo "===> sphinx-build says: well done <===" &&
 
 # tests
 pytest -v && echo "===> pytest/unmarked says: well done <===" &&

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,7 +39,7 @@ pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 mypy --ignore-missing-imports xain && echo "===> mypy says: well done <===" &&
 
 # documentation checks
-SPHINXOPTS="-W" make html && echo "===> sphinx-build says: well done <===" &&
+(cd docs/ && SPHINXOPTS="-W" make html) && echo "===> sphinx-build says: well done <===" &&
 
 # tests
 pytest -v && echo "===> pytest/unmarked says: well done <===" &&

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,7 +39,7 @@ pylint --rcfile=pylint.ini xain && echo "===> pylint says: well done <===" &&
 mypy --ignore-missing-imports xain && echo "===> mypy says: well done <===" &&
 
 # documentation checks
-sphinx-build -W -b html docs/ docs/_build/ && echo "===> sphinx-build says: well done <===" &&
+SPHINXOPTS="-W" make html && echo "===> sphinx-build says: well done <===" &&
 
 # tests
 pytest -v && echo "===> pytest/unmarked says: well done <===" &&

--- a/xain/benchmark/aggregation/final_task_accuracies.py
+++ b/xain/benchmark/aggregation/final_task_accuracies.py
@@ -67,7 +67,7 @@ def prepare_aggregation_data(
 
     Returns:
         A tuple containing a list of `PlotValues` and a list of tuples
-        containing (`XticksLocations`, `XticksLabes`)
+        containing (`XticksLocations`, `XticksLabels`)
 
     """
     group_dir = os.path.join(FLAGS.results_dir, group_name)

--- a/xain/benchmark/aggregation/final_task_accuracies.py
+++ b/xain/benchmark/aggregation/final_task_accuracies.py
@@ -60,17 +60,15 @@ def group_values_by_class(
 def prepare_aggregation_data(
     group_name: str
 ) -> Tuple[List[PlotValues], Optional[Tuple[XticksLocations, XticksLabels]]]:
-    """Constructs and returns curves and xticks_args
+    """Constructs and returns curves and xticks_args.
 
     Args:
         group_name (str): group name for which to construct the curves
 
     Returns:
-        (
-            [("unitary", unitary_accuracies, indices),
-            ("federated", federated_accuracies, indices)],
-            (xticks_locations, xticks_labels))
-        )
+        A tuple containing a list of `PlotValues` and a list of tuples
+        containing (`XticksLocations`, `XticksLabes`)
+
     """
     group_dir = os.path.join(FLAGS.results_dir, group_name)
     # List of tuples (benchmark_name, unitary_accuracy, federated_accuracy)

--- a/xain/benchmark/aggregation/learning_rate.py
+++ b/xain/benchmark/aggregation/learning_rate.py
@@ -53,12 +53,7 @@ def prepare_aggregation_data(group_name: str) -> List[PlotValues]:
         group_name (str): group name for which to construct the curves
 
     Returns:
-        (
-            [
-                ("task_name_1", learning_rates, indices)
-                ("task_name_2", learning_rates, indices)
-            ],
-        )
+        A list of `PlotValues`.
     """
     group_dir = os.path.join(FLAGS.results_dir, group_name)
     # List of tuples (benchmark_name, unitary_accuracy, federated_accuracy)

--- a/xain/benchmark/aggregation/task_accuracies.py
+++ b/xain/benchmark/aggregation/task_accuracies.py
@@ -73,10 +73,7 @@ def prepare_aggregation_data(group_name: str) -> List[PlotValues]:
         group_name (str): group name for which to construct the curves
 
     Returns:
-        ([
-            ("unitary", unitary_accuracies, indices),
-            ("federated", federated_accuracies, indices)
-        ])
+        A list of `PlotValues`.
     """
     group_dir = os.path.join(FLAGS.results_dir, group_name)
     # List of tuples (benchmark_name, unitary_accuracy, federated_accuracy)

--- a/xain/benchmark/net/resnet.py
+++ b/xain/benchmark/net/resnet.py
@@ -107,9 +107,9 @@ def resnet_layer(
     l2_factor=L2_DEFAULT,
     dropout: Optional[float] = None,
 ):
-    """2D Convolution-Batch Normalization-Activation stack builder
+    """2D Convolution-Batch Normalization-Activation stack builder.
 
-    # Arguments
+    Args:
         inputs (tensor): input tensor from input image or previous layer
         num_filters (int): Conv2D number of filters
         kernel_size (int): Conv2D square kernel dimensions
@@ -119,7 +119,7 @@ def resnet_layer(
         conv_first (bool): conv-bn-activation (True) or
             bn-activation-conv (False)
 
-    # Returns
+    Returns:
         x (tensor): tensor as input to the next layer
     """
     conv = Conv2D(

--- a/xain/generator/data.py
+++ b/xain/generator/data.py
@@ -18,13 +18,13 @@ def load(keras_dataset) -> KerasDataset:
 
 
 def extract_validation_set(x: ndarray, y: ndarray, size=6000):
-    """Will extract a validation set of "size" from given x,y pair
+    """Will extract a validation set of "size" from given x,y pair.
 
-    Parameters:
-    x (ndarray): numpy array
-    y (ndarray): numpy array
-    size (int): Size of validation set. Must be smaller than examples count
-                in x, y and multiple of label_count
+    Args:
+        x (ndarray): numpy array
+        y (ndarray): numpy array
+        size (int): Size of validation set. Must be smaller than examples count
+                    in x, y and multiple of label_count
     """
     assert x.shape[0] == y.shape[0]
     assert (


### PR DESCRIPTION
Depends on #112 

- Configured sphinx to be able to generate documentation from docstrings.
- Fixed some bad formatting in some docstrings

The instructions to build the docs also changed since we also need to generate the documentation from the docstrings. This is done with a new make target:
```bash
$ cd docs/
$ make docs
```