### PR TITLE
Rust tests require cmake to be installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            sudo apt-get update && sudo apt-get install -y cmake
+            sudo apt-get update && sudo apt-get install -y cmake golang
 
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,11 @@ jobs:
       - checkout
 
       - run:
+          name: install dependencies
+          command: |
+            apt-get update && apt-get install -y cmake
+
+      - run:
           name: run tests
           command: |
             ./scripts/test_rust.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            apt-get update && apt-get install -y cmake
+            sudo apt-get update && sudo apt-get install -y cmake
 
       - run:
           name: run tests


### PR DESCRIPTION
This fixes the CI currently broken on master.

- Updated CI configuration so that cmake is available for rust tests
- Added golang which is a requirement of boringssl