### PR TITLE
Added a link to the benchmarks documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ $ pip install xain[gpu]
 
 ### Running training sessions and benchmarks
 
-To run training sessions, see the [benchmark package](https://github.com/xainag/xain/tree/master/xain/benchmark)
+To run training sessions, see the [benchmark
+package](https://github.com/xainag/xain/tree/master/xain/benchmark) and the
+[benchmark
+documentation](https://github.com/xainag/xain/blob/master/docs/quick.md#training).
 
 ## Install from source
 


### PR DESCRIPTION
Since the documentation moved under `docs/` added a link in README to the bechmarking documentation.