### PR TITLE
Update benchmark documentation

### DIFF
--- a/docs/quick.md
+++ b/docs/quick.md
@@ -13,7 +13,8 @@ $ python -m xain.benchmark.exec \
     --R=2 \
     --E=2 \
     --C=0.02 \
-    --B=64
+    --B=64 \
+    --nopush_results
 ```
 
 ## Benchmark Suites (using AWS EC2)


### PR DESCRIPTION
This merge request updates the benchmark instructions so that we can run training sessions locally without the need to set aws credentials.