### PR TITLE
Add coordinator logic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "recommonmark",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
 ]
 
 source_suffix = {
@@ -80,3 +81,10 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+
+# intersphinx configuration
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+}

--- a/protobuf/xain/grpc/coordinator.proto
+++ b/protobuf/xain/grpc/coordinator.proto
@@ -23,14 +23,16 @@ message RendezvousReply {
 }
 
 enum State {
-  STANDBY =
-      0;      // Set by the coordinator to signal there is no round in progress
-  ROUND = 1;  // Set by the coordinator to signal what round is currently in
-              // progress
-  FINISHED = 2;  // Set by the coordinator to signal that the session is over
-  READY = 3;     // Set by the participant to signal that it is ready for work
-  TRAINING =
-      4;  // Set by the participant to signal that it is currently training
+  // Set by the coordinator to signal there is no round in progress
+  STANDBY = 0;
+  // Set by the coordinator to signal what round is currently in progress
+  ROUND = 1;
+  // Set by the coordinator to signal that the session is over
+  FINISHED = 2;
+  // Set by the participant to signal that it is ready for work
+  READY = 3;
+  // Set by the participant to signal that it is currently training
+  TRAINING = 4;
 }
 
 message HeartbeatRequest {

--- a/xain/grpc/conftest.py
+++ b/xain/grpc/conftest.py
@@ -4,7 +4,7 @@ import grpc
 import pytest
 
 from xain.grpc import coordinator_pb2_grpc, hellonumproto_pb2_grpc
-from xain.grpc.coordinator import Coordinator, Participants
+from xain.grpc.coordinator import Coordinator, CoordinatorGrpc, Participants
 from xain.grpc.numproto_server import NumProtoServer
 
 
@@ -23,8 +23,9 @@ def greeter_server():
 @pytest.fixture
 def coordinator_service():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    coordinator = Coordinator(Participants())
-    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator, server)
+    coordinator = Coordinator()
+    coordinator_grpc = CoordinatorGrpc(coordinator)
+    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
     server.add_insecure_port("localhost:50051")
     server.start()
     yield coordinator

--- a/xain/grpc/conftest.py
+++ b/xain/grpc/conftest.py
@@ -4,7 +4,7 @@ import grpc
 import pytest
 
 from xain.grpc import coordinator_pb2_grpc, hellonumproto_pb2_grpc
-from xain.grpc.coordinator import Coordinator, CoordinatorGrpc, Participants
+from xain.grpc.coordinator import Coordinator, CoordinatorGrpc
 from xain.grpc.numproto_server import NumProtoServer
 
 
@@ -28,7 +28,7 @@ def coordinator_service():
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
     server.add_insecure_port("localhost:50051")
     server.start()
-    yield coordinator
+    yield coordinator_grpc
     server.stop(0)
 
 

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -1,3 +1,8 @@
+"""Module implementing the networked coordinator using gRPC.
+
+This module implements the Coordinator state machine, the Coordinator gRPC
+service and helper class to keep state about the Participants.
+"""
 import threading
 import time
 from concurrent import futures
@@ -5,7 +10,7 @@ from typing import Dict, List, Optional, Tuple
 
 import grpc
 import numpy as np
-from google.protobuf.interal.python_message import GeneratedProtocolMessageType
+from google.protobuf.internal.python_message import GeneratedProtocolMessageType
 from numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain.fl.coordinator.aggregate import Aggregator, FederatedAveragingAgg
@@ -22,6 +27,10 @@ class ParticipantContext:
 
     In the future we may store more information like in what state a participant is in e.g.
     IDLE, RUNNING, ...
+
+    Args:
+        participant_id (:obj:`str`): The id of the participant. Typically a
+            host:port or public key when using SSL.
     """
 
     def __init__(self, participant_id: str) -> None:
@@ -30,9 +39,9 @@ class ParticipantContext:
 
 
 class Participants:
-    """This class provides some useful methods to handle all the participants connected to
-    a coordinator in a thread safe manner by protecting access to the participants list with a
-    lock.
+    """This class provides some useful methods to handle all the participants
+    connected to a coordinator in a thread safe manner by protecting access to
+    the participants list with a lock.
     """
 
     def __init__(self) -> None:
@@ -43,7 +52,7 @@ class Participants:
         """Adds a new participant to the list of participants.
 
         Args:
-            participant_id (str): The id of the participant to add.
+            participant_id (:obj:`str`): The id of the participant to add.
         """
 
         with self._lock:
@@ -55,7 +64,7 @@ class Participants:
         This will be typically used after a participant is disconnected from the coordinator.
 
         Args:
-            participant_id (str): The id of the participant to remove.
+            participant_id (:obj:`str`): The id of the participant to remove.
         """
 
         with self._lock:
@@ -69,8 +78,7 @@ class Participants:
         the next check.
 
         Returns:
-            float: The next heartbeat to expire or HEARTBEAT + HEARTBEAT_TIMEOUT if there are no
-                no participants.
+            :obj:`float`: The next heartbeat to expire.
         """
 
         with self._lock:
@@ -83,7 +91,7 @@ class Participants:
         """Get the number of participants.
 
         Returns:
-            int: The number of participants in the list.
+            :obj:`int`: The number of participants in the list.
         """
 
         with self._lock:
@@ -92,11 +100,11 @@ class Participants:
     def update_expires(self, participant_id: str) -> None:
         """Updates the heartbeat expiration time for a participant.
 
-        This is currently called by the `Coordinator` every time a participant sends a
+        This is currently called by the :class:`~.Coordinator` every time a participant sends a
         heartbeat.
 
         Args:
-            participant_id (str): The id of the participant.
+            participant_id (:obj:`str`): The id of the participant to update the expire time.
         """
 
         with self._lock:
@@ -105,73 +113,58 @@ class Participants:
             )
 
 
-def monitor_heartbeats(
-    coordinator: Coordinator, terminate_event: threading.Event
-) -> None:
-    """Monitors the heartbeat of participants.
+class Coordinator:
+    """Class implementing the main Coordinator logic. It is implemented as a
+    state machine that reacts to received messages.
 
-    If a heartbeat expires the participant is removed from the list of participants.
+    The states of the Coordinator are:
+        STANDBY: The coordinator is in standby mode, typically when waiting for
+        participants to connect. In this mode the only messages that the
+        coordinator can receive are :class:`~.coordinator_pb2.RendezvousRequest`
+        and :class:`~.coordinator_pb2.HeartbeatRequest`.
+
+        ROUND: A round is currently in progress. During a round the only
+        messages the coordinator can receive are
+        :class:`~.coordinator_pb2.StartTrainingRequest` and
+        :class:`~.coordinator_pb2.EndTrainingRequest`.
+
+        FINISHED: The training session has ended and participants should
+        disconnect from the coordinator.
+
+    States are exchanged during heartbeats so that both coordinators and
+    participants can react to each others state change.
+
+    The flow of the Coordinator:
+        1. The coordinator is started and waits for enough participants to join. `STANDBY`.
+        2. Once enough participants are connected the coordinator starts the rounds. `ROUND N`.
+        3. Repeat step 2. for the given number of rounds
+        4. The training session is over and the coordinator is ready to shutdown. `FINISHED`.
 
     Note:
-        This is meant to be run inside a thread and expects a `threading.Event` to know when
-        it should terminate.
+        :class:`~.coordinator_pb2.RendezvousRequest` is always allowed
+        regardless of which state the coordinator is on.
 
     Args:
-        coordinator (xain.grpc.coordinator.Coordinator): The coordinator to monitor for heartbeats.
+        num_rounds (:obj:`int`, optional): The number of rounds of the training
+            session. Defaults to 10.
+        required_participants(:obj:`int`, optional): The minimum number of
+            participants required to perform a round. Defaults to 10.
+        aggregator: (:class:`~.Aggregator`, optional): The type of aggregation
+            to perform at the end of each round. Defaults to
+            :class:`~.FederatedAveragingAgg`.
+        theta (:obj:`list` of :class:`~numpy.ndarray`, optional): The weights of
+            the global model. Defaults to [].
+        epochs (:obj:`int`, optional): TODO.  Defaults to 0.
+        epochs_base (:obj:`int`, optional): TODO. Defautls to 0.
     """
 
-    while not terminate_event.is_set():
-        print("Monitoring heartbeats")
-        participants_to_remove = []
-
-        for participant in coordinator.participants.participants.values():
-            if participant.heartbeat_expires < time.time():
-                participants_to_remove.append(participant.participant_id)
-
-        for participant_id in participants_to_remove:
-            coordinator.participants.remove(participant_id)
-            print(f"Removing participant {participant_id}")
-
-        next_expiration = coordinator.participants.next_expiration() - time.time()
-
-        print(f"Monitoring heartbeats in {next_expiration:.2f}s")
-        time.sleep(next_expiration)
-
-
-class CoordinatorGrpc(coordinator_pb2_grpc.CoordinatorServicer):
-    def __init__(self, coordinator: Coordinator):
-        self.coordinator = coordinator
-
-    def Rendezvous(
-        self, request: coordinator_pb2.RendezvousRequest, context: grpc.ServicerContext
-    ) -> coordinator_pb2.RendezvousReply:
-        return self.coordinator.on_message(request, context.peer())
-
-    def Heartbeat(
-        self, request: coordinator_pb2.HeartbeatRequest, context: grpc.ServicerContext
-    ) -> coordinator_pb2.HeartbeatReply:
-        return self.coordinator.on_message(request, context.peer())
-
-    def StartTraining(
-        self,
-        request: coordinator_pb2.StartTrainingRequest,
-        context: grpc.ServicerContext,
-    ) -> coordinator_pb2.StartTrainingReply:
-        return self.coordinator.on_message(request, context.peer())
-
-    def EndTraining(
-        self, request: coordinator_pb2.EndTrainingRequest, context: grpc.ServicerContext
-    ) -> coordinator_pb2.EndTrainingReply:
-        return self.coordinator.on_message(request, context.peer())
-
-
-class Coordinator:
     # pylint: disable-msg=too-many-instance-attributes
+    # pylint: disable-msg=dangerous-default-value
     def __init__(
         self,
         num_rounds: int = 10,
         required_participants: int = 10,
-        aggregator: Aggregator = None,
+        aggregator: Optional[Aggregator] = None,
         theta: List[np.ndarray] = [],
         epochs: int = 0,
         epoch_base: int = 0,
@@ -198,6 +191,15 @@ class Coordinator:
     def on_message(
         self, message: GeneratedProtocolMessageType, peer_id: str
     ) -> GeneratedProtocolMessageType:
+        """Coordinator method that implements the state machine.
+
+        Args:
+            message (:class:`~.GeneratedProtocolMessageType`): A protobuf message.
+            peer_id (:obj:`str`): The id of the peer making the request.
+
+        Returns:
+            :class:`~.GeneratedProtocolMessageType`: The reply to be sent back to the peer.
+        """
         print(f"Received: {type(message)} from {peer_id}")
 
         # pylint: disable-msg=no-else-return
@@ -280,7 +282,158 @@ class Coordinator:
             raise NotImplementedError
 
 
+class CoordinatorGrpc(coordinator_pb2_grpc.CoordinatorServicer):
+    """The Coordinator gRPC service.
+
+    The main logic for the Coordinator is decoupled from gRPC and implemented in the
+    :class:`~.Coordinator` class. The gRPC message only handles client requests
+    and forwards the messages to :class:`~.Coordinator`.
+
+    Args:
+        coordinator (:class:`~.Coordinator`): The Coordinator state machine.
+
+    """
+
+    def __init__(self, coordinator: Coordinator):
+        self.coordinator = coordinator
+
+    def Rendezvous(
+        self, request: coordinator_pb2.RendezvousRequest, context: grpc.ServicerContext
+    ) -> coordinator_pb2.RendezvousReply:
+        """The Rendezvous gRPC method.
+
+        A participant contacts the coordinator and the coordinator adds the participant to
+        its list of participants. If the coordinator already has all the participants it
+        needs it tells the participant to try again later.
+
+        Args:
+            request (:class:`~.coordinator_pb2.RendezvousRequest`): The participant's request.
+            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+        Returns:
+            :class:`~.coordinator_pb2.RendezvousReply`: The reply to the
+            participant's request. The reply is an enum containing either:
+
+                ACCEPT: If the :class:`~.Coordinator` does not have enough
+                        participants.
+                LATER: If the :class:`~.Coordinator` already has enough
+                       participants.
+        """
+        return self.coordinator.on_message(request, context.peer())
+
+    def Heartbeat(
+        self, request: coordinator_pb2.HeartbeatRequest, context: grpc.ServicerContext
+    ) -> coordinator_pb2.HeartbeatReply:
+        """The Heartbeat gRPC method.
+
+        Participants periodically send an heartbeat so that the
+        :class:`Coordinator` can detect failures.
+
+        Args:
+            request (:class:`~.coordinator_pb2.HeartbeatRequest`): The
+                participant's request. The participant's request contains the
+                current :class:`~.coordinator_pb2.State` and round number the
+                participant is on.
+            context (:class:`~grpc.ServicerContext`): The context associated
+                with the gRPC request.
+
+        Returns:
+            :class:`~.coordinator_pb2.HeartbeatReply`: The reply to the
+            participant's request. The reply contains both the
+            :class:`~.coordinator_pb2.State` and the current round the
+            coordinator is on. If a training session has not started yet the
+            round number defaults to 0.
+        """
+        return self.coordinator.on_message(request, context.peer())
+
+    def StartTraining(
+        self,
+        request: coordinator_pb2.StartTrainingRequest,
+        context: grpc.ServicerContext,
+    ) -> coordinator_pb2.StartTrainingReply:
+        """The StartTraining gRPC method.
+
+        Once a participant is notified that the :class:`~.Coordinator` is in a round
+        (through the state advertised in the
+        :class:`~.coordinator_pb2.HeartbeatReply`), the participant should call this
+        method in order to get the global model weights in order to start the
+        training for the round.
+
+        Args:
+            request (:class:`~.coordinator_pb2.StartTrainingRequest`): The participant's request.
+            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+        Returns:
+            :class:`~.coordinator_pb2.StartTrainingReply`: The reply to the
+            participant's request. The reply contains the global model weights.
+            """
+        return self.coordinator.on_message(request, context.peer())
+
+    def EndTraining(
+        self, request: coordinator_pb2.EndTrainingRequest, context: grpc.ServicerContext
+    ) -> coordinator_pb2.EndTrainingReply:
+        """The EndTraining gRPC method.
+
+        Once a participant has finished the training for the round it calls this
+        method in order to submit to the :class:`~.Coordinator` the updated weights.
+
+        Args:
+            request (:class:`~.coordinator_pb2.EndTrainingRequest`): The
+                participant's request. The request contains the updated weights as
+                a result of the training as well as any metrics helpful for the
+                :class:`~.Coordinator`.
+            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+        Returns:
+            :class:`~.coordinator_pb2.EndTrainingReply`: The reply to the
+            participant's request. The reply is just and acknowledgment that
+            the :class:`~.Coordinator` successfully received the updated
+            weights.
+        """
+        return self.coordinator.on_message(request, context.peer())
+
+
+def monitor_heartbeats(
+    coordinator: Coordinator, terminate_event: threading.Event
+) -> None:
+    """Monitors the heartbeat of participants.
+
+    If a heartbeat expires the participant is removed from the :class:`~.Participants`.
+
+    Note:
+        This is meant to be run inside a thread and expects an
+        :class:`~threading.Event`, to know when it should terminate.
+
+    Args:
+        coordinator (:class:`~.Coordinator`): The coordinator to monitor for heartbeats.
+        terminate_event (:class:`~threading.Event`): A threading even to signal
+            that this method should terminate.
+    """
+
+    while not terminate_event.is_set():
+        print("Monitoring heartbeats")
+        participants_to_remove = []
+
+        for participant in coordinator.participants.participants.values():
+            if participant.heartbeat_expires < time.time():
+                participants_to_remove.append(participant.participant_id)
+
+        for participant_id in participants_to_remove:
+            coordinator.participants.remove(participant_id)
+            print(f"Removing participant {participant_id}")
+
+        next_expiration = coordinator.participants.next_expiration() - time.time()
+
+        print(f"Monitoring heartbeats in {next_expiration:.2f}s")
+        time.sleep(next_expiration)
+
+
 def serve() -> None:
+    """Main method to start the gRPC service.
+
+    This methods just creates the :class:`~.Coordinator`, setups all threading
+    events and threads and configures and starts the gRPC service.
+    """
     coordinator = Coordinator()
     terminate_event = threading.Event()
     monitor_thread = threading.Thread(

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -155,7 +155,7 @@ class Coordinator:
         theta (:obj:`list` of :class:`~numpy.ndarray`, optional): The weights of
             the global model. Defaults to [].
         epochs (:obj:`int`, optional): TODO.  Defaults to 0.
-        epochs_base (:obj:`int`, optional): TODO. Defautls to 0.
+        epochs_base (:obj:`int`, optional): TODO. Defaults to 0.
     """
 
     # pylint: disable-msg=too-many-instance-attributes
@@ -302,9 +302,9 @@ class CoordinatorGrpc(coordinator_pb2_grpc.CoordinatorServicer):
     ) -> coordinator_pb2.RendezvousReply:
         """The Rendezvous gRPC method.
 
-        A participant contacts the coordinator and the coordinator adds the participant to
-        its list of participants. If the coordinator already has all the participants it
-        needs it tells the participant to try again later.
+        A participant contacts the coordinator and the coordinator adds the
+        participant to its list of participants. If the coordinator already has
+        all the participants it tells the participant to try again later.
 
         Args:
             request (:class:`~.coordinator_pb2.RendezvousRequest`): The participant's request.
@@ -386,7 +386,7 @@ class CoordinatorGrpc(coordinator_pb2_grpc.CoordinatorServicer):
 
         Returns:
             :class:`~.coordinator_pb2.EndTrainingReply`: The reply to the
-            participant's request. The reply is just and acknowledgment that
+            participant's request. The reply is just an acknowledgment that
             the :class:`~.Coordinator` successfully received the updated
             weights.
         """
@@ -406,7 +406,7 @@ def monitor_heartbeats(
 
     Args:
         coordinator (:class:`~.Coordinator`): The coordinator to monitor for heartbeats.
-        terminate_event (:class:`~threading.Event`): A threading even to signal
+        terminate_event (:class:`~threading.Event`): A threading event to signal
             that this method should terminate.
     """
 
@@ -431,7 +431,7 @@ def monitor_heartbeats(
 def serve() -> None:
     """Main method to start the gRPC service.
 
-    This methods just creates the :class:`~.Coordinator`, setups all threading
+    This methods just creates the :class:`~.Coordinator`, sets up all threading
     events and threads and configures and starts the gRPC service.
     """
     coordinator = Coordinator()

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -123,7 +123,7 @@ class Coordinator:
         coordinator can receive are :class:`~.coordinator_pb2.RendezvousRequest`
         and :class:`~.coordinator_pb2.HeartbeatRequest`.
 
-        ROUND: A round is currently in progress. During a round the only
+        ROUND: A round is currently in progress. During a round the important
         messages the coordinator can receive are
         :class:`~.coordinator_pb2.StartTrainingRequest` and
         :class:`~.coordinator_pb2.EndTrainingRequest`.
@@ -154,9 +154,11 @@ class Coordinator:
             :class:`~.FederatedAveragingAgg`.
         theta (:obj:`list` of :class:`~numpy.ndarray`, optional): The weights of
             the global model. Defaults to [].
-        epochs (:obj:`int`, optional): TODO.  Defaults to 0.
-        epochs_base (:obj:`int`, optional): TODO. Defaults to 0.
-    """
+        epochs (:obj:`int`, optional): Number of training iterations local to
+            Participant.  Defaults to 0.
+        epochs_base (:obj:`int`, optional): Global number of epochs since last
+            round. Defaults to 0.
+        """
 
     # pylint: disable-msg=too-many-instance-attributes
     # pylint: disable-msg=dangerous-default-value

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -156,7 +156,7 @@ class Coordinator:
             the global model. Defaults to [].
         epochs (:obj:`int`, optional): Number of training iterations local to
             Participant.  Defaults to 0.
-        epochs_base (:obj:`int`, optional): Global number of epochs since last
+        epochs_base (:obj:`int`, optional): Global number of epochs as of last
             round. Defaults to 0.
         """
 

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -45,6 +45,9 @@ def test_state_standby_round():
     # tests that the coordinator transitions from STANDBY to ROUND once enough participants
     # are connected
     coordinator = Coordinator(required_participants=1)
+
+    assert coordinator.state == coordinator_pb2.STANDBY
+
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND
@@ -75,14 +78,16 @@ def test_end_training():
 
 
 def test_end_training_round_update():
-    # Test that the round number is updated once all participants sent their updates
-    coordinator = Coordinator(required_participants=1)
+    # Test that the round number is updated once all participants send their updates
+    coordinator = Coordinator(required_participants=2)
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
 
     # check that we are currently in round 1
     assert coordinator.round == 1
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
     # check that round number was updated
     assert coordinator.round == 2
@@ -102,7 +107,7 @@ def test_end_training_reinitialize_local_models():
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
-    # once the second participant delivers its updates we the round ends and the local models
+    # once the second participant delivers its updates the round ends and the local models
     # are reinitialized
     assert coordinator.theta_updates == []
     assert coordinator.histories == []

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -1,9 +1,9 @@
 from xain.grpc import coordinator_pb2
-from xain.grpc.coordinator import CoordinatorLogic
+from xain.grpc.coordinator import Coordinator
 
 
 def test_rendezvous_accept():
-    coordinator = CoordinatorLogic()
+    coordinator = Coordinator()
     result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
 
     assert type(result) == coordinator_pb2.RendezvousReply
@@ -11,7 +11,7 @@ def test_rendezvous_accept():
 
 
 def test_rendezvous_later():
-    coordinator = CoordinatorLogic(required_participants=1)
+    coordinator = Coordinator(required_participants=1)
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
     result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
 
@@ -21,7 +21,7 @@ def test_rendezvous_later():
 
 def test_heartbeat_reply():
     # test that the coordinator replies with the correct state and round number
-    coordinator = CoordinatorLogic()
+    coordinator = Coordinator()
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
     result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
 
@@ -41,7 +41,7 @@ def test_heartbeat_reply():
 def test_state_standby_round():
     # tests that the coordinator transitions from STANDBY to ROUND once enough participants
     # are connected
-    coordinator = CoordinatorLogic(required_participants=1)
+    coordinator = Coordinator(required_participants=1)
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -66,7 +66,7 @@ def test_start_training():
 
 
 def test_end_training():
-    # we need to participants so that we can check the status of the local update mid round
+    # we need two participants so that we can check the status of the local update mid round
     # with only one participant it wouldn't work because the local updates state is cleaned at
     # the end of each round
     coordinator = Coordinator(required_participants=2)
@@ -90,6 +90,8 @@ def test_end_training_round_update():
     assert coordinator.round == 1
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    # check we are still in round 1
+    assert coordinator.round == 1
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
     # check that round number was updated

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -1,0 +1,47 @@
+from xain.grpc import coordinator_pb2
+from xain.grpc.coordinator import CoordinatorLogic
+
+
+def test_rendezvous_accept():
+    coordinator = CoordinatorLogic()
+    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+
+    assert type(result) == coordinator_pb2.RendezvousReply
+    assert result.response == coordinator_pb2.RendezvousResponse.ACCEPT
+
+
+def test_rendezvous_later():
+    coordinator = CoordinatorLogic(required_participants=1)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+
+    assert type(result) == coordinator_pb2.RendezvousReply
+    assert result.response == coordinator_pb2.RendezvousResponse.LATER
+
+
+def test_heartbeat_reply():
+    # test that the coordinator replies with the correct state and round number
+    coordinator = CoordinatorLogic()
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
+
+    assert type(result) == coordinator_pb2.HeartbeatReply
+    assert result.state == coordinator_pb2.State.STANDBY
+    assert result.round == 0
+
+    # update the round and state of the coordinator and check again
+    coordinator.state = coordinator_pb2.State.ROUND
+    coordinator.round = 10
+    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
+
+    assert result.state == coordinator_pb2.State.ROUND
+    assert result.round == 10
+
+
+def test_state_standby_round():
+    # tests that the coordinator transitions from STANDBY to ROUND once enough participants
+    # are connected
+    coordinator = CoordinatorLogic(required_participants=1)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+
+    assert coordinator.state == coordinator_pb2.State.ROUND

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -66,6 +66,9 @@ def test_start_training():
 
 
 def test_end_training():
+    # we need to participants so that we can check the status of the local update mid round
+    # with only one participant it wouldn't work because the local updates state is cleaned at
+    # the end of each round
     coordinator = Coordinator(required_participants=2)
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -14,7 +14,12 @@ from xain.grpc import (
     hellonumproto_pb2,
     hellonumproto_pb2_grpc,
 )
-from xain.grpc.coordinator import Coordinator, Participants, monitor_heartbeats
+from xain.grpc.coordinator import (
+    Coordinator,
+    CoordinatorGrpc,
+    Participants,
+    monitor_heartbeats,
+)
 from xain.grpc.participant import end_training, heartbeat, start_training
 
 # Some grpc tests fail on macos.
@@ -52,14 +57,14 @@ def test_participant_rendezvous_accept(participant_stub, coordinator_service):
 def test_participant_rendezvous_later(participant_stub):
 
     # populate participants
+    coordinator = Coordinator()
     required_participants = 10
-    participants = Participants()
     for i in range(required_participants):
-        participants.add(str(i))
+        coordinator.participants.add(str(i))
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(
-        Coordinator(participants, required_participants=required_participants), server
+        CoordinatorGrpc(coordinator), server
     )
     server.add_insecure_port("localhost:50051")
     server.start()

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -92,8 +92,11 @@ def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
     participants.add("participant_1")
     participants.participants["participant_1"].heartbeat_expires = 0
 
+    coordinator = Coordinator()
+    coordinator.participants = participants
+
     terminate_event = threading.Event()
-    monitor_heartbeats(participants, terminate_event)
+    monitor_heartbeats(coordinator, terminate_event)
 
     mock_participants_remove.assert_called_once_with("participant_1")
 
@@ -105,8 +108,11 @@ def test_monitor_heartbeats_remove_participant(_mock_sleep, _mock_event):
     participants.add("participant_1")
     participants.participants["participant_1"].heartbeat_expires = 0
 
+    coordinator = Coordinator()
+    coordinator.participants = participants
+
     terminate_event = threading.Event()
-    monitor_heartbeats(participants, terminate_event)
+    monitor_heartbeats(coordinator, terminate_event)
 
     assert participants.len() == 0
 
@@ -127,44 +133,53 @@ def test_participant_heartbeat(mock_heartbeat_request, _mock_sleep, _mock_event)
 @pytest.mark.integration
 def test_start_training(coordinator_service):
     test_theta = [np.arange(10), np.arange(10, 20)]
+
     # set coordinator global model data
-    coordinator_service.epochs = 5
-    coordinator_service.epoch_base = 2
-    coordinator_service.theta = test_theta
+    coordinator_service.coordinator.epochs = 5
+    coordinator_service.coordinator.epoch_base = 2
+    coordinator_service.coordinator.theta = test_theta
+
     # simulate a participant communicating with coordinator via channel
     with grpc.insecure_channel("localhost:50051") as channel:
         # call startTraining service method on coordinator
         theta, epochs, epoch_base = start_training(channel)
-        # check global model received
-        assert epochs == 5
-        assert epoch_base == 2
-        np.testing.assert_equal(theta, test_theta)
+
+    # check global model received
+    assert epochs == 5
+    assert epoch_base == 2
+    np.testing.assert_equal(theta, test_theta)
 
 
 @pytest.mark.integration
 def test_end_training(coordinator_service):
-    assert not coordinator_service.theta_updates
-    assert not coordinator_service.histories
-    assert not coordinator_service.metricss
+    assert not coordinator_service.coordinator.theta_updates
+    assert not coordinator_service.coordinator.histories
+    assert not coordinator_service.coordinator.metricss
+
     # simulate trained local model data
     test_theta, num = [np.arange(20, 30), np.arange(30, 40)], 2
     his = {"aaa": [1.1, 2.1], "bbb": [3.1, 4.1]}
     mets = 1, [3, 4, 5]
+
     with grpc.insecure_channel("localhost:50051") as channel:
         # call endTraining service method on coordinator
         end_training(channel, (test_theta, num), his, mets)
     # check local model received...
-    assert len(coordinator_service.theta_updates) == 1
-    assert len(coordinator_service.histories) == 1
-    assert len(coordinator_service.metricss) == 1
+
+    assert len(coordinator_service.coordinator.theta_updates) == 1
+    assert len(coordinator_service.coordinator.histories) == 1
+    assert len(coordinator_service.coordinator.metricss) == 1
+
     # first the theta update
-    tu1, tu2 = coordinator_service.theta_updates[0]
+    tu1, tu2 = coordinator_service.coordinator.theta_updates[0]
     assert tu2 == num
     np.testing.assert_equal(tu1, test_theta)
+
     # history values are *floats* so a naive assert == won't do
-    h = coordinator_service.histories[0]
+    h = coordinator_service.coordinator.histories[0]
     assert h.keys() == his.keys()
     for k, vals in his.items():
         np.testing.assert_allclose(h[k], vals)
+
     # finally metrics
-    assert coordinator_service.metricss[0] == mets
+    assert coordinator_service.coordinator.metricss[0] == mets

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -47,27 +47,19 @@ def test_participant_rendezvous_accept(participant_stub, coordinator_service):
     assert reply.response == coordinator_pb2.RendezvousResponse.ACCEPT
 
 
-def mocked_init(self, participants, required_participants=10):
-    """Sets `num_accepted_participants` to be the same as `required_participants` so that
-    the coordinator tells the client to try later.
-    """
-    self.required_participants = required_participants
+# TODO: Fix test so it also runs correctly on macos
+@pytest.mark.integration
+def test_participant_rendezvous_later(participant_stub):
 
     # populate participants
+    required_participants = 10
     participants = Participants()
     for i in range(required_participants):
         participants.add(str(i))
-    self.participants = participants
-
-
-# TODO: Fix test so it also runs correctly on macos
-@pytest.mark.integration
-@mock.patch("xain.grpc.coordinator.Coordinator.__init__", new=mocked_init)
-def test_participant_rendezvous_later(participant_stub):
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(
-        Coordinator(Participants()), server
+        Coordinator(participants, required_participants=required_participants), server
     )
     server.add_insecure_port("localhost:50051")
     server.start()


### PR DESCRIPTION
This is still a work in progress but the main goal is to have the coordinator logic independent of gRPC. This makes it easier to unit tests the coordinator logic and makes it easier to use without gRPC.

The coordinator logic is basically just one method that implements a state machine that reacts to gRPC messages passed to it. This messages can be used both over gRPC or locally without networking.
- Added [intersphinx](http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) to link to external documentation