### PR TITLE
Call `pip` using `python -m` to ensure the right Python interpreter g…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/app
 RUN mkdir output
 
 # Upgrade pip and setuptools
-RUN pip install -U pip==19.3.1 setuptools==41.6.0
+RUN python -m pip install -U pip==19.3.1 setuptools==41.6.0
 
 # First copy scripts and setup.py to install dependencies
 # and avoid reinstalling dependencies when only changing the code
@@ -20,9 +20,9 @@ COPY README.md README.md
 RUN python setup.py egg_info && \
     LN=$(awk '/tensorflow/{ print NR; exit }' xain.egg-info/requires.txt) && \
     IR=$(head -n $LN xain.egg-info/requires.txt | awk '{gsub(/\[.+\]/,"");}1') && \
-    pip install $IR
+    python -m pip install $IR
 
 COPY xain xain
 COPY protobuf protobuf
 
-RUN pip install .
+RUN python -m pip install .

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ POLITE NOTE: We want to point out that running the benchmarks as described below
 XAIN requires [Python 3.6+](https://python.org/). To install the `xain` package just run:
 
 ```shell
-$ pip install xain
+$ python -m pip install xain
 ```
 
 XAIN can also be installed with GPU support through the `gpu` extra feature. To
 install the `xain` package with support for GPUs just run:
 
 ```shell
-$ pip install xain[gpu]
+$ python -m pip install xain[gpu]
 ```
 
 ### Running training sessions and benchmarks
@@ -49,7 +49,7 @@ To clone this repository and to install the XAIN project, please execute the fol
 $ git clone https://github.com/xainag/xain.git
 $ cd xain
 
-$ pip install -e .[dev]
+$ python -m pip install -e .[dev]
 ```
 
 ### Verify Installation

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,14 +7,14 @@ XAIN requires [Python 3.6+](https://python.org/).
 To install the `xain` package just run:
 
 ```shell
-$ pip install xain
+$ python -m pip install xain
 ```
 
 XAIN can also be installed with GPU support through the `gpu` extra feature. To
 install the `xain` package with support for GPUs just run:
 
 ```shell
-$ pip install xain[gpu]
+$ python -m pip install xain[gpu]
 ```
 
 ## Install from source
@@ -32,7 +32,7 @@ To clone this repository and to install the XAIN project, please execute the fol
 $ git clone https://github.com/xainag/xain.git
 $ cd xain
 
-$ pip install -e .[dev]
+$ python -m pip install -e .[dev]
 ```
 
 ### Verify Installation

--- a/rust/xain-grpc/generate-proto-bindings.sh
+++ b/rust/xain-grpc/generate-proto-bindings.sh
@@ -11,7 +11,7 @@ if ! [[ -x "$(command -v protobuf-bin-gen-rust-do-not-use)" ]]; then
     cargo install protobuf-codegen --version 2.8.1
 fi
 
-NUMPROTO_DIR=`pip3 show numproto | grep Location | sed -e 's/^Location: //'`
+NUMPROTO_DIR=`python -m pip show numproto | grep Location | sed -e 's/^Location: //'`
 
 PROTO_FILES="
 ../../protobuf/xain/grpc/coordinator.proto

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $DIR/../
 
-pip install -U pip==19.3.1
-pip install -U setuptools==41.6.0
-pip install -e .[dev]
+python -m pip install -U pip==19.3.1
+python -m pip install -U setuptools==41.6.0
+python -m pip install -e .[dev]


### PR DESCRIPTION
…ets used

Details/motivation: https://snarky.ca/why-you-should-use-python-m-pip/

Even though it might not be strictly necessary for Docker, it's still good to use a uniform approach for calls to `pip`, hence the changes to `Dockerfile`.