### PR TITLE
Checks participants identity

### DIFF
--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -94,7 +94,7 @@ def test_end_training_round_update():
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
     # check we are still in round 1
-    assert coordinator.round == 1
+    assert coordinator.current_round == 1
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
     # check that round number was updated

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numproto import proto_to_ndarray
 
 from xain.grpc import coordinator_pb2
@@ -34,7 +35,7 @@ def test_heartbeat_reply():
 
     # update the round and state of the coordinator and check again
     coordinator.state = coordinator_pb2.State.ROUND
-    coordinator.round = 10
+    coordinator.current_round = 10
     result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
 
     assert result.state == coordinator_pb2.State.ROUND
@@ -51,7 +52,7 @@ def test_state_standby_round():
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND
-    assert coordinator.round == 1
+    assert coordinator.current_round == 1
 
 
 def test_start_training():
@@ -75,9 +76,7 @@ def test_end_training():
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
 
-    assert len(coordinator.theta_updates) == 1
-    assert len(coordinator.histories) == 1
-    assert len(coordinator.metricss) == 1
+    assert len(coordinator.round.updates) == 1
 
 
 def test_end_training_round_update():
@@ -87,7 +86,7 @@ def test_end_training_round_update():
     coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
 
     # check that we are currently in round 1
-    assert coordinator.round == 1
+    assert coordinator.current_round == 1
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
     # check we are still in round 1
@@ -95,7 +94,7 @@ def test_end_training_round_update():
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
     # check that round number was updated
-    assert coordinator.round == 2
+    assert coordinator.current_round == 2
 
 
 def test_end_training_reinitialize_local_models():
@@ -106,17 +105,13 @@ def test_end_training_reinitialize_local_models():
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
 
     # After one participant sends its updates we should have one update in the coordinator
-    assert len(coordinator.theta_updates) == 1
-    assert len(coordinator.histories) == 1
-    assert len(coordinator.metricss) == 1
+    assert len(coordinator.round.updates) == 1
 
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
 
     # once the second participant delivers its updates the round ends and the local models
     # are reinitialized
-    assert coordinator.theta_updates == []
-    assert coordinator.histories == []
-    assert coordinator.metricss == []
+    assert coordinator.round.updates == {}
 
 
 def test_training_finished():
@@ -128,3 +123,25 @@ def test_training_finished():
     coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
 
     assert coordinator.state == coordinator_pb2.State.FINISHED
+
+
+def test_wrong_participant():
+    # coordinator should not accept requests from participants that it has accepted
+    coordinator = Coordinator(required_participants=1)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+
+    with pytest.raises(Exception):
+        coordinator.on_message(coordinator_pb2.StartTrainingRequest(), "peer2")
+
+
+def test_duplicated_update_submit():
+    # the coordinator should not accept multiples updates from the same participant
+    # in the same round
+    coordinator = Coordinator(required_participants=2)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+
+    with pytest.raises(Exception):
+        coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -20,7 +20,7 @@ from xain.grpc.coordinator import (
     Participants,
     monitor_heartbeats,
 )
-from xain.grpc.participant import end_training, heartbeat, start_training
+from xain.grpc.participant import end_training, heartbeat, rendezvous, start_training
 
 # Some grpc tests fail on macos.
 # `pytestmark` when defined on a module will mark all tests in that module.
@@ -141,6 +141,8 @@ def test_start_training(coordinator_service):
 
     # simulate a participant communicating with coordinator via channel
     with grpc.insecure_channel("localhost:50051") as channel:
+        # we need to rendezvous before we can send any other requests
+        rendezvous(channel)
         # call startTraining service method on coordinator
         theta, epochs, epoch_base = start_training(channel)
 
@@ -152,9 +154,7 @@ def test_start_training(coordinator_service):
 
 @pytest.mark.integration
 def test_end_training(coordinator_service):
-    assert not coordinator_service.coordinator.theta_updates
-    assert not coordinator_service.coordinator.histories
-    assert not coordinator_service.coordinator.metricss
+    assert coordinator_service.coordinator.round.updates == {}
 
     # simulate trained local model data
     test_theta, num = [np.arange(20, 30), np.arange(30, 40)], 2
@@ -162,24 +162,27 @@ def test_end_training(coordinator_service):
     mets = 1, [3, 4, 5]
 
     with grpc.insecure_channel("localhost:50051") as channel:
+        # we first need to rendezvous before we can send any other request
+        rendezvous(channel)
         # call endTraining service method on coordinator
         end_training(channel, (test_theta, num), his, mets)
     # check local model received...
 
-    assert len(coordinator_service.coordinator.theta_updates) == 1
-    assert len(coordinator_service.coordinator.histories) == 1
-    assert len(coordinator_service.coordinator.metricss) == 1
+    assert len(coordinator_service.coordinator.round.updates) == 1
+
+    round_ = coordinator_service.coordinator.round
 
     # first the theta update
-    tu1, tu2 = coordinator_service.coordinator.theta_updates[0]
+    _, update = round_.updates.popitem()
+    tu1, tu2 = update["theta_update"]
     assert tu2 == num
     np.testing.assert_equal(tu1, test_theta)
 
     # history values are *floats* so a naive assert == won't do
-    h = coordinator_service.coordinator.histories[0]
+    h = update["history"]
     assert h.keys() == his.keys()
     for k, vals in his.items():
         np.testing.assert_allclose(h[k], vals)
 
     # finally metrics
-    assert coordinator_service.coordinator.metricss[0] == mets
+    assert update["metrics"] == mets


### PR DESCRIPTION
This should **ONLY** be reviewed once #128 is merged.

This merge request adds checks to the participant identity as provided by the grpc context before accepting any requests.

Currently it does the following checks:
- It only accepts requests for participants that have already rendezvous
- It prevents a participant from sending multiple updates in the same round

The `Coordinator` class raises custom exceptions if any of the above conditions happen and the gRPC servicer returns grpc errors back to participant with a description in case any of the above condition happen.