### PR TITLE
Add logging to coordinator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class CustomDevelopCommand(develop):
 install_requires = [
     "typing-extensions~=3.7",  # PSF
     "numpy~=1.15",  # BSD
-    "absl-py~=0.7",  # Apache 2.0
+    "absl-py~=0.8",  # Apache 2.0
     "grpcio~=1.23",  # Apache License 2.0
     "protobuf~=3.9",  # 3-Clause BSD License
     "numproto~=0.3",  # Apache License 2.0

--- a/xain/logger.py
+++ b/xain/logger.py
@@ -1,0 +1,24 @@
+"""This module contains all the xain logging configuration"""
+
+
+import logging
+
+
+def get_logger(name: str, level: str = "INFO") -> logging.Logger:
+    """Returns an instance of the xain logger.
+
+    Args:
+        name (:obj:`str`): The name of the logger. Typically `__name__`.
+        level (int): Threshold for this logger. Can be one of `CRITICAL`,
+            `ERROR`, `WARNING`, `INFO`, `DEBUG`. Defaults to `INFO`.
+
+    Returns:
+        :class:`~logging.Logger`: Configured logger.
+    """
+
+    logging.basicConfig(
+        format="[%(asctime)s] [%(levelname)s] (%(name)s) %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=level,
+    )
+    return logging.getLogger(name)


### PR DESCRIPTION
This should ONLY be reviewed once #138  is merged.

- Configured a project level logger. To get a logger use `xain.logger.get_logger`.
- Updated the version of `absl-py`. The current version took aggressive control of the root logger making it very difficult to configure our own logging. See https://github.com/abseil/abseil-py/issues/99
- Replaced print statements on the coordinator with logging