### PR TITLE
Handle failing participants

### DIFF
--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -279,6 +279,8 @@ class Coordinator:
         self.state = coordinator_pb2.State.STANDBY
         self.current_round = 0
 
+    # TODO: Already fixed on https://github.com/xainag/xain/pull/143
+    # pylint: disable-msg=too-many-branches
     def on_message(
         self, message: GeneratedProtocolMessageType, participant_id: str
     ) -> GeneratedProtocolMessageType:
@@ -313,7 +315,7 @@ class Coordinator:
         # from participants that have not been accepted
         if (
             not isinstance(message, coordinator_pb2.RendezvousRequest)
-            and peer_id not in self.participants.participants.keys()
+            and participant_id not in self.participants.participants.keys()
         ):
             raise Exception
 

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -311,17 +311,6 @@ class Coordinator:
                 "Please try to rendezvous with the coordinator before making a request."
             )
 
-        # Unless this is a RendezvousRequest the coordinator should not accept messages
-        # from participants that have not been accepted
-        if (
-            not isinstance(message, coordinator_pb2.RendezvousRequest)
-            and participant_id not in self.participants.participants.keys()
-        ):
-            raise UnknownParticipantError(
-                f"Unknown participant {participant_id}. "
-                "Please try to rendezvous with the coordinator before making a request."
-            )
-
         # pylint: disable-msg=no-else-return
         if isinstance(message, coordinator_pb2.RendezvousRequest):
             # Handle rendezvous

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -317,7 +317,10 @@ class Coordinator:
             not isinstance(message, coordinator_pb2.RendezvousRequest)
             and participant_id not in self.participants.participants.keys()
         ):
-            raise Exception
+            raise UnknownParticipantError(
+                f"Unknown participant {participant_id}. "
+                "Please try to rendezvous with the coordinator before making a request."
+            )
 
         # pylint: disable-msg=no-else-return
         if isinstance(message, coordinator_pb2.RendezvousRequest):

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -309,6 +309,14 @@ class Coordinator:
                 "Please try to rendezvous with the coordinator before making a request."
             )
 
+        # Unless this is a RendezvousRequest the coordinator should not accept messages
+        # from participants that have not been accepted
+        if (
+            not isinstance(message, coordinator_pb2.RendezvousRequest)
+            and peer_id not in self.participants.participants.keys()
+        ):
+            raise Exception
+
         # pylint: disable-msg=no-else-return
         if isinstance(message, coordinator_pb2.RendezvousRequest):
             # Handle rendezvous

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -12,7 +12,7 @@ from xain.grpc.coordinator import (
 
 def test_rendezvous_accept():
     coordinator = Coordinator()
-    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     assert isinstance(result, coordinator_pb2.RendezvousReply)
     assert result.response == coordinator_pb2.RendezvousResponse.ACCEPT
@@ -20,8 +20,8 @@ def test_rendezvous_accept():
 
 def test_rendezvous_later():
     coordinator = Coordinator(required_participants=1)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    result = coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant2")
 
     assert isinstance(result, coordinator_pb2.RendezvousReply)
     assert result.response == coordinator_pb2.RendezvousResponse.LATER
@@ -30,8 +30,8 @@ def test_rendezvous_later():
 def test_heartbeat_reply():
     # test that the coordinator replies with the correct state and round number
     coordinator = Coordinator()
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "participant1")
 
     assert isinstance(result, coordinator_pb2.HeartbeatReply)
     assert result.state == coordinator_pb2.State.STANDBY
@@ -40,7 +40,7 @@ def test_heartbeat_reply():
     # update the round and state of the coordinator and check again
     coordinator.state = coordinator_pb2.State.ROUND
     coordinator.current_round = 10
-    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer1")
+    result = coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "participant1")
 
     assert result.state == coordinator_pb2.State.ROUND
     assert result.round == 10
@@ -53,7 +53,7 @@ def test_state_standby_round():
 
     assert coordinator.state == coordinator_pb2.STANDBY
 
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND
     assert coordinator.current_round == 1
@@ -62,9 +62,11 @@ def test_state_standby_round():
 def test_start_training():
     test_theta = [np.arange(10), np.arange(10, 20)]
     coordinator = Coordinator(required_participants=1, theta=test_theta)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
-    result = coordinator.on_message(coordinator_pb2.StartTrainingRequest(), "peer1")
+    result = coordinator.on_message(
+        coordinator_pb2.StartTrainingRequest(), "participant1"
+    )
     received_theta = [proto_to_ndarray(nda) for nda in result.theta]
 
     np.testing.assert_equal(test_theta, received_theta)
@@ -75,27 +77,27 @@ def test_end_training():
     # with only one participant it wouldn't work because the local updates state is cleaned at
     # the end of each round
     coordinator = Coordinator(required_participants=2)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant2")
 
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
 
     assert len(coordinator.round.updates) == 1
 
 
 def test_end_training_round_update():
-    # Test that the round number is updated once all participants send their updates
+    # Test that the round number is updated once all participants sent their updates
     coordinator = Coordinator(required_participants=2)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant2")
 
     # check that we are currently in round 1
     assert coordinator.current_round == 1
 
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
     # check we are still in round 1
     assert coordinator.current_round == 1
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant2")
 
     # check that round number was updated
     assert coordinator.current_round == 2
@@ -103,15 +105,15 @@ def test_end_training_round_update():
 
 def test_end_training_reinitialize_local_models():
     coordinator = Coordinator(required_participants=2)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant2")
 
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
 
     # After one participant sends its updates we should have one update in the coordinator
     assert len(coordinator.round.updates) == 1
 
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant2")
 
     # once the second participant delivers its updates the round ends and the local models
     # are reinitialized
@@ -120,11 +122,11 @@ def test_end_training_reinitialize_local_models():
 
 def test_training_finished():
     coordinator = Coordinator(required_participants=1, num_rounds=2)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     # Deliver results for 2 rounds
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
 
     assert coordinator.state == coordinator_pb2.State.FINISHED
 
@@ -132,42 +134,42 @@ def test_training_finished():
 def test_wrong_participant():
     # coordinator should not accept requests from participants that it has accepted
     coordinator = Coordinator(required_participants=1)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     with pytest.raises(UnknownParticipantError):
-        coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "peer2")
+        coordinator.on_message(coordinator_pb2.HeartbeatRequest(), "participant2")
 
     with pytest.raises(UnknownParticipantError):
-        coordinator.on_message(coordinator_pb2.StartTrainingRequest(), "peer2")
+        coordinator.on_message(coordinator_pb2.StartTrainingRequest(), "participant2")
 
     with pytest.raises(UnknownParticipantError):
-        coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer2")
+        coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant2")
 
 
 def test_duplicated_update_submit():
     # the coordinator should not accept multiples updates from the same participant
     # in the same round
     coordinator = Coordinator(required_participants=2)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer2")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant2")
 
-    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
 
     with pytest.raises(DuplicatedUpdateError):
-        coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+        coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "participant1")
 
 
 def test_remove_participant():
     coordinator = Coordinator(required_participants=1)
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND
 
-    coordinator.remove_participant("peer1")
+    coordinator.remove_participant("participant1")
 
     assert coordinator.participants.len() == 0
     assert coordinator.state == coordinator_pb2.State.STANDBY
 
-    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
 
     assert coordinator.state == coordinator_pb2.State.ROUND

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -155,3 +155,19 @@ def test_duplicated_update_submit():
 
     with pytest.raises(DuplicatedUpdateError):
         coordinator.on_message(coordinator_pb2.EndTrainingRequest(), "peer1")
+
+
+def test_remove_participant():
+    coordinator = Coordinator(required_participants=1)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+
+    assert coordinator.state == coordinator_pb2.State.ROUND
+
+    coordinator.remove_participant("peer1")
+
+    assert coordinator.participants.len() == 0
+    assert coordinator.state == coordinator_pb2.State.STANDBY
+
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "peer1")
+
+    assert coordinator.state == coordinator_pb2.State.ROUND

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -95,7 +95,7 @@ def test_heartbeat_denied(participant_stub, coordinator_service):
 
 @mock.patch("threading.Event.is_set", side_effect=[False, True])
 @mock.patch("time.sleep", return_value=None)
-@mock.patch("xain.grpc.coordinator.Participants.remove")
+@mock.patch("xain.grpc.coordinator.Coordinator.remove_participant")
 def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
     participants = Participants()
     participants.add("participant_1")


### PR DESCRIPTION
This should ONLY be reviewed once #139 is merged.

The coordinator is now aware of participants that disconnect and reacts to it by transition to the STANDBY state if the the current number of participants falls bellow `required_participants`.

Also renamed some references of `peer` to `participant` for more consistent terminology.