### PR TITLE
Check state transitions

### DIFF
--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -289,8 +289,6 @@ class Coordinator:
         self.state = coordinator_pb2.State.STANDBY
         self.current_round = 0
 
-    # TODO: Already fixed on https://github.com/xainag/xain/pull/143
-    # pylint: disable-msg=too-many-branches
     def on_message(
         self, message: GeneratedProtocolMessageType, participant_id: str
     ) -> GeneratedProtocolMessageType:

--- a/xain/grpc/coordinator.py
+++ b/xain/grpc/coordinator.py
@@ -644,8 +644,8 @@ def monitor_heartbeats(
             that this method should terminate.
     """
 
+    logger.info("Heartbeat monitor starting...")
     while not terminate_event.is_set():
-        logger.info("Heartbeat monitor starting...")
         participants_to_remove = []
 
         for participant in coordinator.participants.participants.values():

--- a/xain/grpc/test_coordinator_logic.py
+++ b/xain/grpc/test_coordinator_logic.py
@@ -6,6 +6,7 @@ from xain.grpc import coordinator_pb2
 from xain.grpc.coordinator import (
     Coordinator,
     DuplicatedUpdateError,
+    InvalidRequestError,
     UnknownParticipantError,
 )
 
@@ -70,6 +71,16 @@ def test_start_training():
     received_theta = [proto_to_ndarray(nda) for nda in result.theta]
 
     np.testing.assert_equal(test_theta, received_theta)
+
+
+def start_training_wrong_state():
+    # if the coordinator receives a StartTraining request while not in the
+    # ROUND state it will raise an exception
+    coordinator = Coordinator(required_participants=2)
+    coordinator.on_message(coordinator_pb2.RendezvousRequest(), "participant1")
+
+    with pytest.raises(InvalidRequestError):
+        coordinator.on_message(coordinator_pb2.StartTrainingRequest(), "participant1")
 
 
 def test_end_training():

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -164,11 +164,21 @@ def test_start_training(coordinator_service):
 
 @pytest.mark.integration
 def test_start_training_denied(participant_stub, coordinator_service):
-    # heartbeat requests are only allowed if the participant has already
+    # start training requests are only allowed if the participant has already
     # rendezvous with the coordinator
     with pytest.raises(grpc.RpcError):
         reply = participant_stub.StartTraining(coordinator_pb2.StartTrainingRequest())
         assert reply.status_code == grpc.StatusCode.PERMISSION_DENIED
+
+
+@pytest.mark.integration
+def test_start_training_failed_precondition(participant_stub, coordinator_service):
+    # start training requests are only allowed if the coordinator is in the
+    # ROUND state
+    participant_stub.Rendezvous(coordinator_pb2.RendezvousRequest())
+    with pytest.raises(grpc.RpcError):
+        reply = participant_stub.StartTraining(coordinator_pb2.StartTrainingRequest())
+        assert reply.status_code == grpc.StatusCode.FAILED_PRECONDITION
 
 
 @pytest.mark.integration

--- a/xain/grpc/test_grpc.py
+++ b/xain/grpc/test_grpc.py
@@ -144,6 +144,7 @@ def test_start_training(coordinator_service):
     test_theta = [np.arange(10), np.arange(10, 20)]
 
     # set coordinator global model data
+    coordinator_service.coordinator.required_participants = 1
     coordinator_service.coordinator.epochs = 5
     coordinator_service.coordinator.epoch_base = 2
     coordinator_service.coordinator.theta = test_theta


### PR DESCRIPTION
This should ONLY be reviewed once #141 is merged.

- deny StartTraining requests from participants if the coordinator is not in the ROUND state.
- small refactor to split the method that handles client requests.
- added grpc error handling for the invalid requests
- added tests

