### PR TITLE
Updated sphinx to also document the benchmarks package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/_code_reference/
+docs/_code_reference*
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,8 @@ help:
 .PHONY: help Makefile
 
 docs:
-	sphinx-apidoc --doc-project "Code Reference" -f -d 3 --tocfile index -o ./_code_reference/ ../xain/
+	sphinx-apidoc --doc-project "Code Reference XAIN" -f -d 3 --tocfile index -o ./_code_reference_xain/ ../xain/
+	sphinx-apidoc --doc-project "Code Reference Benchmarks" -f -d 3 --tocfile index -o ./_code_reference_benchmarks/ ../benchmarks/
 	make html
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,4 +44,5 @@ API Documentation
 .. toctree::
     :maxdepth: 1
 
-    _code_reference/index
+    _code_reference_xain/index
+    _code_reference_benchmarks/index


### PR DESCRIPTION
With this pr the sphinx documentation will have two sections under _API Documentation_:
- _Code Reference XAIN_
- _Code Reference Benchmarks_